### PR TITLE
warning: this ‘for’ clause does not guard... [-Wmisleading-indentation]      for (i=(int)uReadSize-3; (i--)>0;)

### DIFF
--- a/quazip/zip.c
+++ b/quazip/zip.c
@@ -530,7 +530,7 @@ local ZPOS64_T zip64local_SearchCentralDir(const zlib_filefunc64_32_def* pzlib_f
     if (ZREAD64(*pzlib_filefunc_def,filestream,buf,uReadSize)!=uReadSize)
       break;
 
-    for (i=(int)uReadSize-3; (i--)>0;)
+    for (i=(int)uReadSize-3; (i--)>0;){
       if (((*(buf+i))==0x50) && ((*(buf+i+1))==0x4b) &&
         ((*(buf+i+2))==0x05) && ((*(buf+i+3))==0x06))
       {
@@ -540,6 +540,7 @@ local ZPOS64_T zip64local_SearchCentralDir(const zlib_filefunc64_32_def* pzlib_f
 
       if (uPosFound!=0)
         break;
+    }
   }
   TRYFREE(buf);
   return uPosFound;

--- a/quazip/zip.c
+++ b/quazip/zip.c
@@ -537,10 +537,9 @@ local ZPOS64_T zip64local_SearchCentralDir(const zlib_filefunc64_32_def* pzlib_f
         uPosFound = uReadPos+i;
         break;
       }
-
+    }
       if (uPosFound!=0)
         break;
-    }
   }
   TRYFREE(buf);
   return uPosFound;


### PR DESCRIPTION
Fix warning buffer