### PR TITLE
added: codec for zip filenames in JCompress::extractDir() for filenam…

### DIFF
--- a/quazip/JlCompress.cpp
+++ b/quazip/JlCompress.cpp
@@ -353,9 +353,10 @@ QStringList JlCompress::extractFiles(QuaZip &zip, const QStringList &files, cons
     return extracted;
 }
 
-QStringList JlCompress::extractDir(QString fileCompressed, QString dir) {
+QStringList JlCompress::extractDir(QString fileCompressed, QString dir,QTextCodec* fileNameCodec) {
     // Apro lo zip
     QuaZip zip(fileCompressed);
+    if(fileNameCodec!=NULL) zip.setFileNameCodec(fileNameCodec);
     return extractDir(zip, dir);
 }
 

--- a/quazip/JlCompress.h
+++ b/quazip/JlCompress.h
@@ -151,7 +151,7 @@ public:
       left empty.
       \return The list of the full paths of the files extracted, empty on failure.
       */
-    static QStringList extractDir(QString fileCompressed, QString dir = QString());
+    static QStringList extractDir(QString fileCompressed, QString dir = QString(), QTextCodec* fileNameCodec= NULL);
     /// Get the file list.
     /**
       \return The list of the files in the archive, or, more precisely, the


### PR DESCRIPTION
This is just an example, I had some issue with zip files with non-standard filenames encoding, i solved the issue by adding an optional parameter that let you choose the desired codec, I thought it might be helpful