### PR TITLE
Fix building with non-Apple Clang on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
-project(QuaZip)
 cmake_minimum_required(VERSION 2.6)
+project(QuaZip)
 
 # CMP0042: Explicitly acknowledge MACOSX_RPATH
 # (introduced in CMake 2.8.12, enabled by default in CMake 3.0,


### PR DESCRIPTION
See https://github.com/macports/macports-ports/commit/98445d69fc13be9c968abe4c597de8324b0ceee6
for explanations.

Also, CMake documents clearly say that cmake_minimum_required should be the first command in top-level CMakeLists.txt. [1]

[1] https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html