### PR TITLE
Added QStringLiteral and QString::fromStdString

### DIFF
--- a/quazip/JlCompress.cpp
+++ b/quazip/JlCompress.cpp
@@ -92,7 +92,7 @@ bool JlCompress::compressSubDir(QuaZip* zip, QString dir, QString origDir, bool 
 	if (dir != origDir) {
 		QuaZipFile dirZipFile(zip);
 		if (!dirZipFile.open(QIODevice::WriteOnly,
-			QuaZipNewInfo(origDirectory.relativeFilePath(dir) + "/", dir), 0, 0, 0)) {
+            QuaZipNewInfo(origDirectory.relativeFilePath(dir) + QStringLiteral("/"), dir), 0, 0, 0)) {
 				return false;
 		}
 		dirZipFile.close();
@@ -148,7 +148,7 @@ bool JlCompress::extractFile(QuaZip* zip, QString fileName, QString fileDest) {
 
     // Controllo esistenza cartella file risultato
     QDir curDir;
-    if (fileDest.endsWith('/')) {
+    if (fileDest.endsWith(QStringLiteral("/"))) {
         if (!curDir.mkpath(fileDest)) {
             return false;
         }
@@ -163,7 +163,7 @@ bool JlCompress::extractFile(QuaZip* zip, QString fileName, QString fileDest) {
         return false;
 
     QFile::Permissions srcPerm = info.getPermissions();
-    if (fileDest.endsWith('/') && QFileInfo(fileDest).isDir()) {
+    if (fileDest.endsWith(QStringLiteral("/")) && QFileInfo(fileDest).isDir()) {
         if (srcPerm != 0) {
             QFile(fileDest).setPermissions(srcPerm);
         }
@@ -375,9 +375,9 @@ QStringList JlCompress::extractDir(QuaZip &zip, const QString &dir)
         QString name = zip.getCurrentFileName();
         QString absFilePath = directory.absoluteFilePath(name);
         QString absCleanPath = QDir::cleanPath(absFilePath);
-        if (!absCleanPath.startsWith(absCleanDir + "/"))
+        if (!absCleanPath.startsWith(absCleanDir + QStringLiteral("/")))
             continue;
-        if (!extractFile(&zip, "", absFilePath)) {
+        if (!extractFile(&zip, QStringLiteral(""), absFilePath)) {
             removeFile(extracted);
             return QStringList();
         }

--- a/quazip/quaziodevice.cpp
+++ b/quazip/quaziodevice.cpp
@@ -155,13 +155,13 @@ bool QuaZIODevice::open(QIODevice::OpenMode mode)
     }
     if ((mode & QIODevice::ReadOnly) != 0) {
         if (inflateInit(&d->zins) != Z_OK) {
-            setErrorString(d->zins.msg);
+            setErrorString(QString::fromStdString(d->zins.msg));
             return false;
         }
     }
     if ((mode & QIODevice::WriteOnly) != 0) {
         if (deflateInit(&d->zouts, Z_DEFAULT_COMPRESSION) != Z_OK) {
-            setErrorString(d->zouts.msg);
+            setErrorString(QString::fromStdString(d->zouts.msg));
             return false;
         }
     }
@@ -172,13 +172,13 @@ void QuaZIODevice::close()
 {
     if ((openMode() & QIODevice::ReadOnly) != 0) {
         if (inflateEnd(&d->zins) != Z_OK) {
-            setErrorString(d->zins.msg);
+            setErrorString(QString::fromStdString(d->zins.msg));
         }
     }
     if ((openMode() & QIODevice::WriteOnly) != 0) {
         flush();
         if (deflateEnd(&d->zouts) != Z_OK) {
-            setErrorString(d->zouts.msg);
+            setErrorString(QString::fromStdString(d->zouts.msg));
         }
     }
     QIODevice::close();

--- a/quazip/quaziodevice.cpp
+++ b/quazip/quaziodevice.cpp
@@ -155,13 +155,13 @@ bool QuaZIODevice::open(QIODevice::OpenMode mode)
     }
     if ((mode & QIODevice::ReadOnly) != 0) {
         if (inflateInit(&d->zins) != Z_OK) {
-            setErrorString(QString::fromStdString(d->zins.msg));
+            setErrorString(QString::fromLocal8Bit(d->zins.msg));
             return false;
         }
     }
     if ((mode & QIODevice::WriteOnly) != 0) {
         if (deflateInit(&d->zouts, Z_DEFAULT_COMPRESSION) != Z_OK) {
-            setErrorString(QString::fromStdString(d->zouts.msg));
+            setErrorString(QString::fromLocal8Bit(d->zouts.msg));
             return false;
         }
     }
@@ -172,13 +172,13 @@ void QuaZIODevice::close()
 {
     if ((openMode() & QIODevice::ReadOnly) != 0) {
         if (inflateEnd(&d->zins) != Z_OK) {
-            setErrorString(QString::fromStdString(d->zins.msg));
+            setErrorString(QString::fromLocal8Bit(d->zins.msg));
         }
     }
     if ((openMode() & QIODevice::WriteOnly) != 0) {
         flush();
         if (deflateEnd(&d->zouts) != Z_OK) {
-            setErrorString(QString::fromStdString(d->zouts.msg));
+            setErrorString(QString::fromLocal8Bit(d->zouts.msg));
         }
     }
     QIODevice::close();

--- a/quazip/quazipdir.cpp
+++ b/quazip/quazipdir.cpp
@@ -55,7 +55,7 @@ QuaZipDir::QuaZipDir(const QuaZipDir &that):
 QuaZipDir::QuaZipDir(QuaZip *zip, const QString &dir):
     d(new QuaZipDirPrivate(zip, dir))
 {
-    if (d->dir.startsWith('/'))
+    if (d->dir.startsWith(QStringLiteral("/")))
         d->dir = d->dir.mid(1);
 }
 
@@ -86,24 +86,24 @@ QuaZip::CaseSensitivity QuaZipDir::caseSensitivity() const
 
 bool QuaZipDir::cd(const QString &directoryName)
 {
-    if (directoryName == "/") {
-        d->dir = "";
+    if (directoryName == QStringLiteral("/")) {
+        d->dir = QStringLiteral("");
         return true;
     }
     QString dirName = directoryName;
-    if (dirName.endsWith('/'))
+    if (dirName.endsWith(QStringLiteral("/")))
         dirName.chop(1);
-    if (dirName.contains('/')) {
+    if (dirName.contains(QStringLiteral("/"))) {
         QuaZipDir dir(*this);
-        if (dirName.startsWith('/')) {
+        if (dirName.startsWith(QStringLiteral("/"))) {
 #ifdef QUAZIP_QUAZIPDIR_DEBUG
             qDebug("QuaZipDir::cd(%s): going to /",
                     dirName.toUtf8().constData());
 #endif
-            if (!dir.cd("/"))
+            if (!dir.cd(QStringLiteral("/")))
                 return false;
         }
-        QStringList path = dirName.split('/', QString::SkipEmptyParts);
+        QStringList path = dirName.split(QStringLiteral("/"), QString::SkipEmptyParts);
         for (QStringList::const_iterator i = path.constBegin();
                 i != path.end();
                 ++i) {
@@ -119,15 +119,15 @@ bool QuaZipDir::cd(const QString &directoryName)
         d->dir = dir.path();
         return true;
     } else { // no '/'
-        if (dirName == ".") {
+        if (dirName == QStringLiteral(".")) {
             return true;
-        } else if (dirName == "..") {
+        } else if (dirName == QStringLiteral("..")) {
             if (isRoot()) {
                 return false;
             } else {
-                int slashPos = d->dir.lastIndexOf('/');
+                int slashPos = d->dir.lastIndexOf(QStringLiteral("/"));
                 if (slashPos == -1) {
-                    d->dir = "";
+                    d->dir = QStringLiteral("");
                 } else {
                     d->dir = d->dir.left(slashPos);
                 }
@@ -138,7 +138,7 @@ bool QuaZipDir::cd(const QString &directoryName)
                 if (isRoot())
                     d->dir = dirName;
                 else
-                    d->dir += "/" + dirName;
+                    d->dir += QStringLiteral("/") + dirName;
                 return true;
             } else {
                 return false;
@@ -149,7 +149,7 @@ bool QuaZipDir::cd(const QString &directoryName)
 
 bool QuaZipDir::cdUp()
 {
-    return cd("..");
+    return cd(QStringLiteral(".."));
 }
 
 uint QuaZipDir::count() const
@@ -247,10 +247,10 @@ class QuaZipDirComparator
 
 QString QuaZipDirComparator::getExtension(const QString &name)
 {
-    if (name.endsWith('.') || name.indexOf('.', 1) == -1) {
-        return "";
+    if (name.endsWith(QStringLiteral(".")) || name.indexOf(QStringLiteral("."), 1) == -1) {
+        return QStringLiteral("");
     } else {
-        return name.mid(name.lastIndexOf('.') + 1);
+        return name.mid(name.lastIndexOf(QStringLiteral(".")) + 1);
     }
 
 }
@@ -277,9 +277,9 @@ bool QuaZipDirComparator::operator()(const QuaZipFileInfo64 &info1,
         & (QDir::Name | QDir::Time | QDir::Size | QDir::Type);
     if ((sort & QDir::DirsFirst) == QDir::DirsFirst
             || (sort & QDir::DirsLast) == QDir::DirsLast) {
-        if (info1.name.endsWith('/') && !info2.name.endsWith('/'))
+        if (info1.name.endsWith(QStringLiteral("/")) && !info2.name.endsWith(QStringLiteral("/")))
             return (sort & QDir::DirsFirst) == QDir::DirsFirst;
-        else if (!info1.name.endsWith('/') && info2.name.endsWith('/'))
+        else if (!info1.name.endsWith(QStringLiteral("/")) && info2.name.endsWith(QStringLiteral("/")))
             return (sort & QDir::DirsLast) == QDir::DirsLast;
     }
     bool result;
@@ -325,7 +325,7 @@ bool QuaZipDirPrivate::entryInfoList(QStringList nameFilters,
 {
     QString basePath = simplePath();
     if (!basePath.isEmpty())
-        basePath += "/";
+        basePath += QStringLiteral("/");
     int baseLength = basePath.length();
     result.clear();
     QuaZipDirRestoreCurrent saveCurrent(zip);
@@ -351,8 +351,8 @@ bool QuaZipDirPrivate::entryInfoList(QStringList nameFilters,
             continue;
         bool isDir = false;
         bool isReal = true;
-        if (relativeName.contains('/')) {
-            int indexOfSlash = relativeName.indexOf('/');
+        if (relativeName.contains(QStringLiteral("/"))) {
+            int indexOfSlash = relativeName.indexOf(QStringLiteral("/"));
             // something like "subdir/"
             isReal = indexOfSlash == relativeName.length() - 1;
             relativeName = relativeName.left(indexOfSlash + 1);
@@ -448,12 +448,12 @@ QStringList QuaZipDir::entryList(QDir::Filters filters,
 
 bool QuaZipDir::exists(const QString &filePath) const
 {
-    if (filePath == "/" || filePath.isEmpty())
+    if (filePath == QStringLiteral("/") || filePath.isEmpty())
         return true;
     QString fileName = filePath;
-    if (fileName.endsWith('/'))
+    if (fileName.endsWith(QStringLiteral("/")))
         fileName.chop(1);
-    if (fileName.contains('/')) {
+    if (fileName.contains(QStringLiteral("/"))) {
         QFileInfo fileInfo(fileName);
 #ifdef QUAZIP_QUAZIPDIR_DEBUG
         qDebug("QuaZipDir::exists(): fileName=%s, fileInfo.fileName()=%s, "
@@ -464,9 +464,9 @@ bool QuaZipDir::exists(const QString &filePath) const
         QuaZipDir dir(*this);
         return dir.cd(fileInfo.path()) && dir.exists(fileInfo.fileName());
     } else {
-        if (fileName == "..") {
+        if (fileName == QStringLiteral("..")) {
             return !isRoot();
-        } else if (fileName == ".") {
+        } else if (fileName == QStringLiteral(".")) {
             return true;
         } else {
             QStringList entries = entryList(QDir::AllEntries, QDir::NoSort);
@@ -482,11 +482,11 @@ bool QuaZipDir::exists(const QString &filePath) const
 #endif
             Qt::CaseSensitivity cs = QuaZip::convertCaseSensitivity(
                     d->caseSensitivity);
-            if (filePath.endsWith('/')) {
+            if (filePath.endsWith(QStringLiteral("/"))) {
                 return entries.contains(filePath, cs);
             } else {
                 return entries.contains(fileName, cs)
-                    || entries.contains(fileName + "/", cs);
+                    || entries.contains(fileName + QStringLiteral("/"), cs);
             }
         }
     }
@@ -524,7 +524,7 @@ QString QuaZipDir::path() const
 
 QString QuaZipDir::relativeFilePath(const QString &fileName) const
 {
-    return QDir("/" + d->dir).relativeFilePath(fileName);
+    return QDir(QStringLiteral("/") + d->dir).relativeFilePath(fileName);
 }
 
 void QuaZipDir::setCaseSensitivity(QuaZip::CaseSensitivity caseSensitivity)
@@ -545,12 +545,12 @@ void QuaZipDir::setNameFilters(const QStringList &nameFilters)
 void QuaZipDir::setPath(const QString &path)
 {
     QString newDir = path;
-    if (newDir == "/") {
-        d->dir = "";
+    if (newDir == QStringLiteral("/")) {
+        d->dir = QStringLiteral("");
     } else {
-        if (newDir.endsWith('/'))
+        if (newDir.endsWith(QStringLiteral("/")))
             newDir.chop(1);
-        if (newDir.startsWith('/'))
+        if (newDir.startsWith(QStringLiteral("/")))
             newDir = newDir.mid(1);
         d->dir = newDir;
     }

--- a/quazip/quazipfile.cpp
+++ b/quazip/quazipfile.cpp
@@ -112,7 +112,7 @@ class QuaZipFilePrivate {
       {
         zip=new QuaZip(zipName);
         this->fileName=fileName;
-        if (this->fileName.startsWith('/'))
+        if (this->fileName.startsWith(QStringLiteral("/")))
             this->fileName = this->fileName.mid(1);
         this->caseSensitivity=cs;
       }
@@ -232,7 +232,7 @@ void QuaZipFile::setFileName(const QString& fileName, QuaZip::CaseSensitivity cs
     return;
   }
   p->fileName=fileName;
-  if (p->fileName.startsWith('/'))
+  if (p->fileName.startsWith(QStringLiteral("/")))
       p->fileName = p->fileName.mid(1);
   p->caseSensitivity=cs;
 }

--- a/quazip/quazipnewinfo.cpp
+++ b/quazip/quazipnewinfo.cpp
@@ -121,7 +121,7 @@ void QuaZipNewInfo::setFilePermissions(const QString &file)
 
 void QuaZipNewInfo::setPermissions(QFile::Permissions permissions)
 {
-    QuaZipNewInfo_setPermissions(this, permissions, name.endsWith('/'));
+    QuaZipNewInfo_setPermissions(this, permissions, name.endsWith(QStringLiteral("/")));
 }
 
 void QuaZipNewInfo::setFileNTFSTimes(const QString &fileName)


### PR DESCRIPTION
Hi stachenov,

i added QStringLiteral and  QString::fromStdString to chars for people who use the defines like:
QT_NO_CAST_FROM_ASCII,
QT_NO_CAST_TO_ASCII,
QT_NO_URL_CAST_FROM_STRING,
Wihout QStringLiteral and QString::fromStdString the cant use this wonderfull library.
Alsow its a performace boost and safty feature.

Many greetings, isy
