### PR TITLE
Install the FindQuaZip.cmake in the right prefix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,4 +60,4 @@ set(QUAZIP_LIB_TARGET_NAME quazip${QUAZIP_LIB_VERSION_SUFFIX} CACHE
 
 add_subdirectory(quazip)
 
-install(FILES FindQuaZip.cmake RENAME FindQuaZip${QUAZIP_LIB_VERSION_SUFFIX}.cmake DESTINATION ${CMAKE_ROOT}/Modules)
+install(FILES FindQuaZip.cmake RENAME FindQuaZip${QUAZIP_LIB_VERSION_SUFFIX}.cmake DESTINATION share/cmake)


### PR DESCRIPTION
It should go wherever CMAKE_INSTALL_PREFIX is installing.
This fixes the build on flatpak and should also fix it for other cross
compilation setups.