### PR TITLE
Replace deprecated Qt functions with their equivalents

### DIFF
--- a/quazip/quagzipfile.cpp
+++ b/quazip/quagzipfile.cpp
@@ -57,13 +57,13 @@ bool QuaGzipFilePrivate::open(FileId id, QIODevice::OpenMode mode,
     char modeString[2];
     modeString[0] = modeString[1] = '\0';
     if ((mode & QIODevice::Append) != 0) {
-        error = QuaGzipFile::trUtf8("QIODevice::Append is not "
+        error = QuaGzipFile::tr("QIODevice::Append is not "
                 "supported for GZIP");
         return false;
     }
     if ((mode & QIODevice::ReadOnly) != 0
             && (mode & QIODevice::WriteOnly) != 0) {
-        error = QuaGzipFile::trUtf8("Opening gzip for both reading"
+        error = QuaGzipFile::tr("Opening gzip for both reading"
             " and writing is not supported");
         return false;
     } else if ((mode & QIODevice::ReadOnly) != 0) {
@@ -71,13 +71,13 @@ bool QuaGzipFilePrivate::open(FileId id, QIODevice::OpenMode mode,
     } else if ((mode & QIODevice::WriteOnly) != 0) {
         modeString[0] = 'w';
     } else {
-        error = QuaGzipFile::trUtf8("You can open a gzip either for reading"
+        error = QuaGzipFile::tr("You can open a gzip either for reading"
             " or for writing. Which is it?");
         return false;
     }
     gzd = open(id, modeString);
     if (gzd == NULL) {
-        error = QuaGzipFile::trUtf8("Could not gzopen() file");
+        error = QuaGzipFile::tr("Could not gzopen() file");
         return false;
     }
     return true;

--- a/quazip/quagzipfile.cpp
+++ b/quazip/quagzipfile.cpp
@@ -57,27 +57,46 @@ bool QuaGzipFilePrivate::open(FileId id, QIODevice::OpenMode mode,
     char modeString[2];
     modeString[0] = modeString[1] = '\0';
     if ((mode & QIODevice::Append) != 0) {
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 0, 0))
         error = QuaGzipFile::tr("QIODevice::Append is not "
                 "supported for GZIP");
+#else
+        error = QuaGzipFile::trUtf8("QIODevice::Append is not "
+                "supported for GZIP");
+#endif
         return false;
     }
     if ((mode & QIODevice::ReadOnly) != 0
             && (mode & QIODevice::WriteOnly) != 0) {
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 0, 0))
         error = QuaGzipFile::tr("Opening gzip for both reading"
             " and writing is not supported");
+#else
+        error = QuaGzipFile::trUtf8("Opening gzip for both reading"
+            " and writing is not supported");
+#endif
         return false;
     } else if ((mode & QIODevice::ReadOnly) != 0) {
         modeString[0] = 'r';
     } else if ((mode & QIODevice::WriteOnly) != 0) {
         modeString[0] = 'w';
     } else {
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 0, 0))
         error = QuaGzipFile::tr("You can open a gzip either for reading"
             " or for writing. Which is it?");
+#else
+        error = QuaGzipFile::trUtf8("You can open a gzip either for reading"
+            " or for writing. Which is it?");
+#endif
         return false;
     }
     gzd = open(id, modeString);
     if (gzd == NULL) {
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 0, 0))
         error = QuaGzipFile::tr("Could not gzopen() file");
+#else
+        error = QuaGzipFile::trUtf8("Could not gzopen() file");
+#endif
         return false;
     }
     return true;

--- a/quazip/quaziodevice.cpp
+++ b/quazip/quaziodevice.cpp
@@ -144,12 +144,12 @@ QIODevice *QuaZIODevice::getIoDevice() const
 bool QuaZIODevice::open(QIODevice::OpenMode mode)
 {
     if ((mode & QIODevice::Append) != 0) {
-        setErrorString(trUtf8("QIODevice::Append is not supported for"
+        setErrorString(tr("QIODevice::Append is not supported for"
                     " QuaZIODevice"));
         return false;
     }
     if ((mode & QIODevice::ReadWrite) == QIODevice::ReadWrite) {
-        setErrorString(trUtf8("QIODevice::ReadWrite is not supported for"
+        setErrorString(tr("QIODevice::ReadWrite is not supported for"
                     " QuaZIODevice"));
         return false;
     }

--- a/quazip/quaziodevice.cpp
+++ b/quazip/quaziodevice.cpp
@@ -144,13 +144,23 @@ QIODevice *QuaZIODevice::getIoDevice() const
 bool QuaZIODevice::open(QIODevice::OpenMode mode)
 {
     if ((mode & QIODevice::Append) != 0) {
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 0, 0))
         setErrorString(tr("QIODevice::Append is not supported for"
                     " QuaZIODevice"));
+#else
+        setErrorString(trUtf8("QIODevice::Append is not supported for"
+                    " QuaZIODevice"));
+#endif
         return false;
     }
     if ((mode & QIODevice::ReadWrite) == QIODevice::ReadWrite) {
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 0, 0))
         setErrorString(tr("QIODevice::ReadWrite is not supported for"
                     " QuaZIODevice"));
+#else
+        setErrorString(trUtf8("QIODevice::ReadWrite is not supported for"
+                    " QuaZIODevice"));
+#endif
         return false;
     }
     if ((mode & QIODevice::ReadOnly) != 0) {

--- a/quazip/quazipdir.cpp
+++ b/quazip/quazipdir.cpp
@@ -390,7 +390,7 @@ bool QuaZipDirPrivate::entryInfoList(QStringList nameFilters,
                 == Qt::CaseInsensitive)
             srt |= QDir::IgnoreCase;
         QuaZipDirComparator lessThan(srt);
-        qSort(list.begin(), list.end(), lessThan);
+        std::sort(list.begin(), list.end(), lessThan);
     }
     QuaZipDir_convertInfoList(list, result);
     return true;

--- a/quazip/quazipdir.cpp
+++ b/quazip/quazipdir.cpp
@@ -390,7 +390,11 @@ bool QuaZipDirPrivate::entryInfoList(QStringList nameFilters,
                 == Qt::CaseInsensitive)
             srt |= QDir::IgnoreCase;
         QuaZipDirComparator lessThan(srt);
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 2, 0))
         std::sort(list.begin(), list.end(), lessThan);
+#else
+        qSort(list.begin(), list.end(), lessThan);
+#endif
     }
     QuaZipDir_convertInfoList(list, result);
     return true;

--- a/quazip/quazipnewinfo.cpp
+++ b/quazip/quazipnewinfo.cpp
@@ -134,7 +134,7 @@ void QuaZipNewInfo::setFileNTFSTimes(const QString &fileName)
     }
     setFileNTFSmTime(fi.lastModified());
     setFileNTFSaTime(fi.lastRead());
-    setFileNTFScTime(fi.created());
+    setFileNTFScTime(fi.birthTime());
 }
 
 static void setNTFSTime(QByteArray &extra, const QDateTime &time, int position,

--- a/quazip/quazipnewinfo.cpp
+++ b/quazip/quazipnewinfo.cpp
@@ -134,7 +134,11 @@ void QuaZipNewInfo::setFileNTFSTimes(const QString &fileName)
     }
     setFileNTFSmTime(fi.lastModified());
     setFileNTFSaTime(fi.lastRead());
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 10, 0))
     setFileNTFScTime(fi.birthTime());
+#else
+    setFileNTFScTime(fi.created());
+#endif
 }
 
 static void setNTFSTime(QByteArray &extra, const QDateTime &time, int position,


### PR DESCRIPTION
QFileInfo::created() ->QFileInfo::birthTime()
QObject()::trUtf8() -> QObject()::tr()
qSort() -> std::sort()