### PR TITLE
Adds -lz to LIBS on MacOS X, fixes #23

### DIFF
--- a/quazip/quazip.pro
+++ b/quazip/quazip.pro
@@ -59,6 +59,10 @@ unix:!symbian {
 	
 }
 
+macx {
+    LIBS += -lz
+}
+
 win32 {
     headers.path=$$PREFIX/include/quazip
     headers.files=$$HEADERS


### PR DESCRIPTION
Theoretically this may be needed in other unices too, but I'm working on MacOS X at the moment and this works without disrupting anyone else.