### PR TITLE
fix qztest build error.

### DIFF
--- a/qztest/testquazip.cpp
+++ b/qztest/testquazip.cpp
@@ -233,7 +233,7 @@ void TestQuaZip::setOsCode()
     checkZip.goToFirstFile();
     QuaZipFileInfo64 fi;
     QVERIFY(checkZip.getCurrentFileInfo(&fi));
-    QCOMPARE(fi.versionCreated >> 8, static_cast<quint16>(osCode));
+    QCOMPARE(static_cast<uint>(fi.versionCreated) >> 8, osCode);
 }
 
 void TestQuaZip::setDataDescriptorWritingEnabled()


### PR DESCRIPTION
If int is bigger than quint16 then you will get the following
linker error:

.obj/testquazip.o: In function `TestQuaZip::setOsCode()':
testquazip.cpp:(.text+0x42bd): undefined reference to `bool QTest::qCompare<int, unsigned short>(int const&, unsigned short const&, char const*, char const*, char const*, int)'
collect2: error: ld returned 1 exit status

This error indicates the two parameters of QCOMPARE do not have the same type.

This occurs because integral promotions can be applied to fi.versionCreated.