### PR TITLE
Fix Qt5 deprecated warnings

### DIFF
--- a/quazip/quagzipfile.cpp
+++ b/quazip/quagzipfile.cpp
@@ -57,13 +57,13 @@ bool QuaGzipFilePrivate::open(FileId id, QIODevice::OpenMode mode,
     char modeString[2];
     modeString[0] = modeString[1] = '\0';
     if ((mode & QIODevice::Append) != 0) {
-        error = QuaGzipFile::trUtf8("QIODevice::Append is not "
+        error = QuaGzipFile::tr("QIODevice::Append is not "
                 "supported for GZIP");
         return false;
     }
     if ((mode & QIODevice::ReadOnly) != 0
             && (mode & QIODevice::WriteOnly) != 0) {
-        error = QuaGzipFile::trUtf8("Opening gzip for both reading"
+        error = QuaGzipFile::tr("Opening gzip for both reading"
             " and writing is not supported");
         return false;
     } else if ((mode & QIODevice::ReadOnly) != 0) {
@@ -71,13 +71,13 @@ bool QuaGzipFilePrivate::open(FileId id, QIODevice::OpenMode mode,
     } else if ((mode & QIODevice::WriteOnly) != 0) {
         modeString[0] = 'w';
     } else {
-        error = QuaGzipFile::trUtf8("You can open a gzip either for reading"
+        error = QuaGzipFile::tr("You can open a gzip either for reading"
             " or for writing. Which is it?");
         return false;
     }
     gzd = open(id, modeString);
     if (gzd == NULL) {
-        error = QuaGzipFile::trUtf8("Could not gzopen() file");
+        error = QuaGzipFile::tr("Could not gzopen() file");
         return false;
     }
     return true;

--- a/quazip/quaziodevice.cpp
+++ b/quazip/quaziodevice.cpp
@@ -185,12 +185,12 @@ QIODevice *QuaZIODevice::getIoDevice() const
 bool QuaZIODevice::open(QIODevice::OpenMode mode)
 {
     if ((mode & QIODevice::Append) != 0) {
-        setErrorString(trUtf8("QIODevice::Append is not supported for"
+        setErrorString(tr("QIODevice::Append is not supported for"
                     " QuaZIODevice"));
         return false;
     }
     if ((mode & QIODevice::ReadWrite) == QIODevice::ReadWrite) {
-        setErrorString(trUtf8("QIODevice::ReadWrite is not supported for"
+        setErrorString(tr("QIODevice::ReadWrite is not supported for"
                     " QuaZIODevice"));
         return false;
     }

--- a/quazip/quazip.pro
+++ b/quazip/quazip.pro
@@ -29,11 +29,15 @@ QMAKE_PKGCONFIG_REQUIRES = Qt5Core
 # 2.0, VERSION to 2.0.0.
 # And so on.
 
+greaterThan(QT_MAJOR_VERSION, 4) {
+    # disable all the Qt APIs deprecated before Qt 6.0.0
+    DEFINES += QT_DISABLE_DEPRECATED_BEFORE=0x060000
+}
 
 # This one handles dllimport/dllexport directives.
 DEFINES += QUAZIP_BUILD
-DEFINES+=QT_NO_CAST_FROM_ASCII
-DEFINES+=QT_NO_CAST_TO_ASCII
+DEFINES += QT_NO_CAST_FROM_ASCII
+DEFINES += QT_NO_CAST_TO_ASCII
 # You'll need to define this one manually if using a build system other
 # than qmake or using QuaZIP sources directly in your project.
 CONFIG(staticlib): DEFINES += QUAZIP_STATIC

--- a/quazip/quazipdir.cpp
+++ b/quazip/quazipdir.cpp
@@ -390,7 +390,11 @@ bool QuaZipDirPrivate::entryInfoList(QStringList nameFilters,
                 == Qt::CaseInsensitive)
             srt |= QDir::IgnoreCase;
         QuaZipDirComparator lessThan(srt);
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 2, 0))
+        std::sort(list.begin(), list.end(), lessThan);
+#else
         qSort(list.begin(), list.end(), lessThan);
+#endif
     }
     QuaZipDir_convertInfoList(list, result);
     return true;

--- a/quazip/quazipnewinfo.cpp
+++ b/quazip/quazipnewinfo.cpp
@@ -134,7 +134,11 @@ void QuaZipNewInfo::setFileNTFSTimes(const QString &fileName)
     }
     setFileNTFSmTime(fi.lastModified());
     setFileNTFSaTime(fi.lastRead());
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 10, 0))
+    setFileNTFScTime(fi.birthTime());
+#else
     setFileNTFScTime(fi.created());
+#endif
 }
 
 static void setNTFSTime(QByteArray &extra, const QDateTime &time, int position,

--- a/quazip/quazipnewinfo.h
+++ b/quazip/quazipnewinfo.h
@@ -148,8 +148,9 @@ struct QUAZIP_EXPORT QuaZipNewInfo {
   /**
    * If the file doesn't exist, a warning is printed to the stderr and nothing
    * is done. Otherwise, all three times, as reported by
-   * QFileInfo::lastModified(), QFileInfo::lastRead() and QFileInfo::created(),
-   * are written to the NTFS extra field record.
+   * QFileInfo::lastModified(), QFileInfo::lastRead() and
+   * QFileInfo::birthTime() (>=Qt5.10) or QFileInfo::created(), are written to
+   * the NTFS extra field record.
    *
    * The NTFS record is written to
    * both the local and the global extra fields, updating the existing record

--- a/qztest/qztest.pro
+++ b/qztest/qztest.pro
@@ -12,6 +12,11 @@ win32 {
     DEFINES += NOMINMAX
 }
 
+greaterThan(QT_MAJOR_VERSION, 4) {
+    # disable all the Qt APIs deprecated before Qt 6.0.0
+    DEFINES += QT_DISABLE_DEPRECATED_BEFORE=0x060000
+}
+
 CONFIG(staticlib): DEFINES += QUAZIP_STATIC
 
 # Input

--- a/qztest/testjlcompress.cpp
+++ b/qztest/testjlcompress.cpp
@@ -154,8 +154,8 @@ void TestJlCompress::compressDir()
     QVERIFY(JlCompress::compressDir(zipName, "compressDir_tmp", true, QDir::Hidden));
     // get the file list and check it
     QStringList fileList = JlCompress::getFileList(zipName);
-    qSort(fileList);
-    qSort(expected);
+    fileList.sort();
+    expected.sort();
     QCOMPARE(fileList, expected);
     removeTestFiles(fileNames, "compressDir_tmp");
     curDir.remove(zipName);

--- a/qztest/testquazip.cpp
+++ b/qztest/testquazip.cpp
@@ -62,7 +62,7 @@ void TestQuaZip::getFileList()
 {
     QFETCH(QString, zipName);
     QFETCH(QStringList, fileNames);
-    qSort(fileNames);
+    fileNames.sort();
     QDir curDir;
     if (curDir.exists(zipName)) {
         if (!curDir.remove(zipName))
@@ -79,7 +79,7 @@ void TestQuaZip::getFileList()
     QVERIFY(testZip.goToFirstFile());
     QString firstFile = testZip.getCurrentFileName();
     QStringList fileList = testZip.getFileNameList();
-    qSort(fileList);
+    fileList.sort();
     QCOMPARE(fileList, fileNames);
     QHash<QString, QFileInfo> srcInfo;
     foreach (QString fileName, fileNames) {
@@ -178,7 +178,7 @@ void TestQuaZip::setFileNameCodec()
     QFETCH(QString, zipName);
     QFETCH(QStringList, fileNames);
     QFETCH(QByteArray, encoding);
-    qSort(fileNames);
+    fileNames.sort();
     QDir curDir;
     if (curDir.exists(zipName)) {
         if (!curDir.remove(zipName))
@@ -194,13 +194,13 @@ void TestQuaZip::setFileNameCodec()
     QuaZip testZip(zipName);
     QVERIFY(testZip.open(QuaZip::mdUnzip));
     QStringList fileList = testZip.getFileNameList();
-    qSort(fileList);
+    fileList.sort();
     QVERIFY(fileList[0] != fileNames[0]);
     testZip.close();
     testZip.setFileNameCodec(encoding);
     QVERIFY(testZip.open(QuaZip::mdUnzip));
     fileList = testZip.getFileNameList();
-    qSort(fileList);
+    fileList.sort();
     QCOMPARE(fileList, fileNames);
     testZip.close();
     // clean up

--- a/qztest/testquazipfileinfo.cpp
+++ b/qztest/testquazipfileinfo.cpp
@@ -41,7 +41,11 @@ void TestQuaZipFileInfo::getNTFSTime()
         QuaZipFile zipFile(&zip);
         QDateTime lm = fileInfo.lastModified().toUTC();
         QDateTime lr = fileInfo.lastRead().toUTC();
-        QDateTime cr = fileInfo.created().toUTC();
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 10, 0))
+        QDateTime cr = fileInfo.birthTime();
+#else
+        QDateTime cr = fileInfo.created();
+#endif
         mTicks = (static_cast<qint64>(base.date().daysTo(lm.date()))
                 * Q_UINT64_C(86400000)
                 + static_cast<qint64>(base.time().msecsTo(lm.time())))
@@ -101,7 +105,11 @@ void TestQuaZipFileInfo::getNTFSTime()
         zip.close();
         QCOMPARE(zipFileInfo.getNTFSmTime(), fileInfo.lastModified());
         QCOMPARE(zipFileInfo.getNTFSaTime(), fileInfo.lastRead());
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 10, 0))
+        QCOMPARE(zipFileInfo.getNTFScTime(), fileInfo.birthTime());
+#else
         QCOMPARE(zipFileInfo.getNTFScTime(), fileInfo.created());
+#endif
     }
     removeTestFiles(testFiles);
     curDir.remove(zipName);

--- a/qztest/testquazipnewinfo.cpp
+++ b/qztest/testquazipnewinfo.cpp
@@ -39,7 +39,11 @@ void TestQuaZipNewInfo::setFileNTFSTimes()
         QFileInfo fileInfo("tmp/test.txt");
         QDateTime lm = fileInfo.lastModified().toUTC();
         QDateTime lr = fileInfo.lastRead().toUTC();
-        QDateTime cr = fileInfo.created().toUTC();
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 10, 0))
+        QDateTime cr = fileInfo.birthTime();
+#else
+        QDateTime cr = fileInfo.created();
+#endif
         mTicks = (static_cast<qint64>(base.date().daysTo(lm.date()))
                 * Q_UINT64_C(86400000)
                 + static_cast<qint64>(base.time().msecsTo(lm.time())))


### PR DESCRIPTION
trUtf8 is deprecated in Qt 5.0
qSort is deprecated in Qt 5.2
QFileInfo::created() is deprecated in Qt 5.10

Changes as discussed in PR #22
This PR also makes the changes to the qztest project