### PR TITLE
Fix typo (compilation fails on this typo)

### DIFF
--- a/quazip/quazipfileinfo.cpp
+++ b/quazip/quazipfileinfo.cpp
@@ -24,7 +24,7 @@ see quazip/(un)zip.h files for details. Basically it's the zlib license.
 
 #include "quazipfileinfo.h"
 
-#include <QDataStream>>
+#include <QDataStream>
 
 static QFile::Permissions permissionsFromExternalAttr(quint32 externalAttr) {
     quint32 uPerm = (externalAttr & 0xFFFF0000u) >> 16;


### PR DESCRIPTION
redundant trailing `>` removed