### PR TITLE
Fix includes to include QtCore/

### DIFF
--- a/quazip/JlCompress.cpp
+++ b/quazip/JlCompress.cpp
@@ -24,7 +24,6 @@ see quazip/(un)zip.h files for details. Basically it's the zlib license.
 */
 
 #include "JlCompress.h"
-#include <QDebug>
 
 static bool copyData(QIODevice &inFile, QIODevice &outFile)
 {

--- a/quazip/JlCompress.h
+++ b/quazip/JlCompress.h
@@ -29,10 +29,10 @@ see quazip/(un)zip.h files for details. Basically it's the zlib license.
 #include "quazip.h"
 #include "quazipfile.h"
 #include "quazipfileinfo.h"
-#include <QString>
-#include <QDir>
-#include <QFileInfo>
-#include <QFile>
+#include <QtCore/QString>
+#include <QtCore/QDir>
+#include <QtCore/QFileInfo>
+#include <QtCore/QFile>
 
 /// Utility class for typical operations.
 /**

--- a/quazip/qioapi.cpp
+++ b/quazip/qioapi.cpp
@@ -15,12 +15,12 @@
 
 #include "ioapi.h"
 #include "quazip_global.h"
-#include <QIODevice>
+#include <QtCore/QIODevice>
 #if (QT_VERSION >= 0x050100)
 #define QUAZIP_QSAVEFILE_BUG_WORKAROUND
 #endif
 #ifdef QUAZIP_QSAVEFILE_BUG_WORKAROUND
-#include <QSaveFile>
+#include <QtCore/QSaveFile>
 #endif
 
 /* I've found an old Unix (a SunOS 4.1.3_U1) without all SEEK_* defined.... */

--- a/quazip/quaadler32.h
+++ b/quazip/quaadler32.h
@@ -26,7 +26,7 @@ Original ZIP package is copyrighted by Gilles Vollant and contributors,
 see quazip/(un)zip.h files for details. Basically it's the zlib license.
 */
 
-#include <QByteArray>
+#include <QtCore/QByteArray>
 
 #include "quachecksum32.h"
 

--- a/quazip/quachecksum32.h
+++ b/quazip/quachecksum32.h
@@ -25,7 +25,7 @@ Original ZIP package is copyrighted by Gilles Vollant and contributors,
 see quazip/(un)zip.h files for details. Basically it's the zlib license.
 */
 
-#include <QByteArray>
+#include <QtCore/QByteArray>
 #include "quazip_global.h"
 
 /// Checksum interface.

--- a/quazip/quagzipfile.cpp
+++ b/quazip/quagzipfile.cpp
@@ -22,7 +22,7 @@ Original ZIP package is copyrighted by Gilles Vollant and contributors,
 see quazip/(un)zip.h files for details. Basically it's the zlib license.
 */
 
-#include <QFile>
+#include <QtCore/QFile>
 
 #include "quagzipfile.h"
 

--- a/quazip/quagzipfile.h
+++ b/quazip/quagzipfile.h
@@ -25,7 +25,7 @@ Original ZIP package is copyrighted by Gilles Vollant and contributors,
 see quazip/(un)zip.h files for details. Basically it's the zlib license.
 */
 
-#include <QIODevice>
+#include <QtCore/QIODevice>
 #include "quazip_global.h"
 
 #include <zlib.h>

--- a/quazip/quaziodevice.cpp
+++ b/quazip/quaziodevice.cpp
@@ -155,11 +155,11 @@ int QuaZIODevicePrivate::doFlush(QString &error)
 // #define QUAZIP_ZIODEVICE_DEBUG_OUTPUT
 // #define QUAZIP_ZIODEVICE_DEBUG_INPUT
 #ifdef QUAZIP_ZIODEVICE_DEBUG_OUTPUT
-#include <QFile>
+#include <QtCore/QFile>
 static QFile debug;
 #endif
 #ifdef QUAZIP_ZIODEVICE_DEBUG_INPUT
-#include <QFile>
+#include <QtCore/QFile>
 static QFile indebug;
 #endif
 

--- a/quazip/quaziodevice.h
+++ b/quazip/quaziodevice.h
@@ -25,7 +25,7 @@ Original ZIP package is copyrighted by Gilles Vollant and contributors,
 see quazip/(un)zip.h files for details. Basically it's the zlib license.
 */
 
-#include <QIODevice>
+#include <QtCore/QIODevice>
 #include "quazip_global.h"
 
 #include <zlib.h>

--- a/quazip/quazip.cpp
+++ b/quazip/quazip.cpp
@@ -22,9 +22,9 @@ Original ZIP package is copyrighted by Gilles Vollant, see
 quazip/(un)zip.h files for details, basically it's zlib license.
  **/
 
-#include <QFile>
-#include <QFlags>
-#include <QHash>
+#include <QtCore/QFile>
+#include <QtCore/QFlags>
+#include <QtCore/QHash>
 
 #include "quazip.h"
 

--- a/quazip/quazip.h
+++ b/quazip/quazip.h
@@ -25,9 +25,9 @@ Original ZIP package is copyrighted by Gilles Vollant, see
 quazip/(un)zip.h files for details, basically it's zlib license.
  **/
 
-#include <QString>
-#include <QStringList>
-#include <QTextCodec>
+#include <QtCore/QString>
+#include <QtCore/QStringList>
+#include <QtCore/QTextCodec>
 
 #include "zip.h"
 #include "unzip.h"

--- a/quazip/quazipdir.cpp
+++ b/quazip/quazipdir.cpp
@@ -24,8 +24,8 @@ see quazip/(un)zip.h files for details. Basically it's the zlib license.
 
 #include "quazipdir.h"
 
-#include <QSet>
-#include <QSharedData>
+#include <QtCore/QSet>
+#include <QtCore/QSharedData>
 
 /// \cond internal
 class QuaZipDirPrivate: public QSharedData {

--- a/quazip/quazipdir.h
+++ b/quazip/quazipdir.h
@@ -29,9 +29,9 @@ class QuaZipDirPrivate;
 
 #include "quazip.h"
 #include "quazipfileinfo.h"
-#include <QDir>
-#include <QList>
-#include <QSharedDataPointer>
+#include <QtCore/QDir>
+#include <QtCore/QList>
+#include <QtCore/QSharedDataPointer>
 
 /// Provides ZIP archive navigation.
 /**

--- a/quazip/quazipfile.h
+++ b/quazip/quazipfile.h
@@ -25,7 +25,7 @@ Original ZIP package is copyrighted by Gilles Vollant, see
 quazip/(un)zip.h files for details, basically it's zlib license.
  **/
 
-#include <QIODevice>
+#include <QtCore/QIODevice>
 
 #include "quazip_global.h"
 #include "quazip.h"

--- a/quazip/quazipfileinfo.cpp
+++ b/quazip/quazipfileinfo.cpp
@@ -24,7 +24,7 @@ see quazip/(un)zip.h files for details. Basically it's the zlib license.
 
 #include "quazipfileinfo.h"
 
-#include <QDataStream>
+#include <QtCore/QDataStream>
 
 static QFile::Permissions permissionsFromExternalAttr(quint32 externalAttr) {
     quint32 uPerm = (externalAttr & 0xFFFF0000u) >> 16;

--- a/quazip/quazipfileinfo.h
+++ b/quazip/quazipfileinfo.h
@@ -25,10 +25,10 @@ Original ZIP package is copyrighted by Gilles Vollant and contributors,
 see quazip/(un)zip.h files for details. Basically it's the zlib license.
 */
 
-#include <QByteArray>
-#include <QDateTime>
-#include <QFile>
-#include <QHash>
+#include <QtCore/QByteArray>
+#include <QtCore/QDateTime>
+#include <QtCore/QFile>
+#include <QtCore/QHash>
 
 #include "quazip_global.h"
 

--- a/quazip/quazipnewinfo.cpp
+++ b/quazip/quazipnewinfo.cpp
@@ -22,7 +22,7 @@ Original ZIP package is copyrighted by Gilles Vollant and contributors,
 see quazip/(un)zip.h files for details. Basically it's the zlib license.
 */
 
-#include <QFileInfo>
+#include <QtCore/QFileInfo>
 
 #include "quazipnewinfo.h"
 

--- a/quazip/quazipnewinfo.h
+++ b/quazip/quazipnewinfo.h
@@ -25,9 +25,9 @@ Original ZIP package is copyrighted by Gilles Vollant, see
 quazip/(un)zip.h files for details, basically it's zlib license.
  **/
 
-#include <QDateTime>
-#include <QFile>
-#include <QString>
+#include <QtCore/QDateTime>
+#include <QtCore/QFile>
+#include <QtCore/QString>
 
 #include "quazip_global.h"
 


### PR DESCRIPTION
Allow using other compilers / IDEs that are not qmake / QtDesigner to use this without adding an additional include directory.
Qt's own moc also generates includes with <module/file>. 
