### PR TITLE
Added virtual destructor

### DIFF
--- a/quazip/quachecksum32.h
+++ b/quazip/quachecksum32.h
@@ -53,6 +53,8 @@ class QUAZIP_EXPORT QuaChecksum32
 {
 
 public:
+	virtual ~QuaChecksum32() {}
+
 	///Calculates the checksum for data.
 	/** \a data source data
 	 * \return data checksum


### PR DESCRIPTION
Adds a virtual destructor to `QuaChecksum32` because it has virtual member functions.

Tested compilation with:

```
mkdir build && cd build
CXXFLAGS="-Wall -Wextra -Wnon-virtual-dtor -Werror" cmake ..
make
```

Fixes #53.