### PR TITLE
fix building qztest/testquazipfileinfo.cpp with Qt 4.8.7 by declaring…

### DIFF
--- a/qztest/testquazipfileinfo.cpp
+++ b/qztest/testquazipfileinfo.cpp
@@ -14,6 +14,11 @@
 #include "quazip/quazipfileinfo.h"
 #include "quazip/quazipnewinfo.h"
 
+#if QT_VERSION < 0x050000
+Q_DECLARE_METATYPE(QList<qint32>);
+Q_DECLARE_METATYPE(QuaExtraFieldHash);
+#endif
+
 TestQuaZipFileInfo::TestQuaZipFileInfo(QObject *parent) :
     QObject(parent)
 {


### PR DESCRIPTION
… missing metatypes, fixes #62"