### PR TITLE
qztest/TestQuaZipFileInfo: disable birthTime check on Linux, as it mi…

### DIFF
--- a/qztest/testquazipfileinfo.cpp
+++ b/qztest/testquazipfileinfo.cpp
@@ -111,10 +111,14 @@ void TestQuaZipFileInfo::getNTFSTime()
         zip.close();
         QCOMPARE(zipFileInfo.getNTFSmTime(), fileInfo.lastModified());
         QCOMPARE(zipFileInfo.getNTFSaTime(), fileInfo.lastRead());
+#ifndef Q_OS_LINUX
+// There is some controversy about birthtime on various Linux version, and this test likely to fail.
+// Disabling for now
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 10, 0))
         QCOMPARE(zipFileInfo.getNTFScTime(), fileInfo.birthTime());
 #else
         QCOMPARE(zipFileInfo.getNTFScTime(), fileInfo.created());
+#endif
 #endif
     }
     removeTestFiles(testFiles);


### PR DESCRIPTION
…ght fail on some distros/filesystems, fixes #61
See for example https://unix.stackexchange.com/questions/304779/is-there-still-no-linux-kernel-interface-to-get-file-creation-date for background. 