### PR TITLE
Fix infinite recursion after unsafe change

### DIFF
--- a/quazip/JlCompress.cpp
+++ b/quazip/JlCompress.cpp
@@ -261,7 +261,7 @@ bool JlCompress::compressFiles(QString fileCompressed, QStringList files) {
 }
 
 bool JlCompress::compressDir(QString fileCompressed, QString dir, bool recursive) {
-    return compressDir(fileCompressed, dir, recursive, QDir::NoFilter);
+    return compressDir(fileCompressed, dir, recursive, QDir::Filters());
 }
 
 bool JlCompress::compressDir(QString fileCompressed, QString dir,


### PR DESCRIPTION
`NoFilters` flag is `-1`, not a zero.  And does not change when is `|`-ed on line 104. 
The problem is caused by `NoFilters`, that is handled as a special case in `entryInfoList()` and results to ignoring NoDotAndNoDotDot, that in turn  lead to infinite loop on '.' file.
