### PR TITLE
Fix pkgconfig include dir

### DIFF
--- a/quazip.pc.cmakein
+++ b/quazip.pc.cmakein
@@ -1,12 +1,12 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
-libdir=${prefix}/lib@LIB_SUFFIX@
-includedir=${prefix}/include
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@/@QUAZIP_LIB_VERSION_PREFIX@Quazip
 
 
 Name: Quazip
 Description: Quazip Library
 Version: @QUAZIP_LIB_VERSION@
 Libs: -l@QUAZIP_LIB_VERSION_PREFIX@Quazip
-Cflags:
+Cflags: -I${includedir}
 Requires: Qt5Core


### PR DESCRIPTION
...and use GNUInstallDirs here as well. No need to set `LIB_SUFFIX` separately anymore.

Successfully tested by building chessx with a simple quazip-unbundle patch (without having to touch sources to fix include dir prefix etc.): https://gitweb.gentoo.org/repo/gentoo.git/tree/games-board/chessx/files/chessx-1.5.4-system-quazip.patch