### PR TITLE
Fix compile with Qt 6

### DIFF
--- a/quazip/JlCompress.h
+++ b/quazip/JlCompress.h
@@ -33,7 +33,11 @@ see quazip/(un)zip.h files for details. Basically it's the zlib license.
 #include <QtCore/QDir>
 #include <QtCore/QFileInfo>
 #include <QtCore/QFile>
-#include <QtCore/QTextCodec>
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+#  include <QtCore5Compat/QTextCodec>
+#else
+#  include <QtCore/QTextCodec>
+#endif
 
 /// Utility class for typical operations.
 /**

--- a/quazip/quazip.h
+++ b/quazip/quazip.h
@@ -27,7 +27,11 @@ quazip/(un)zip.h files for details, basically it's zlib license.
 
 #include <QtCore/QString>
 #include <QtCore/QStringList>
-#include <QtCore/QTextCodec>
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+#  include <QtCore5Compat/QTextCodec>
+#else
+#  include <QtCore/QTextCodec>
+#endif
 
 #include "zip.h"
 #include "unzip.h"


### PR DESCRIPTION
In Qt 6 QTextCodec is removed from Core into a Qt 5 Compat module, it's the only removed class that is in use. This fixes the include so it compiles with Qt 6 using the Qt 5 Compat module.

I see there is already work with CMake that probably will conflict with Qt 6 CMake changes so I'm waiting with that.

All that needs to be added is:
option(BUILD_WITH_QT6 "Compile with Qt 6")

Then do:
`find_package(Qt6 COMPONENTS Core Core5Compat)`
Add a section for if(Qt6Core_FOUND)
`set(QTCORE_LIBRARIES Qt6::Core Qt6::Core5Compat)`
and change qt5_wrap_cpp to qt6_wrap_cpp
etc.
