### PR TITLE
Set up GitHub CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,70 @@
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+name: CI
+
+jobs:
+
+  ubuntu:
+    name: "cmake on ${{ matrix.runner }}"
+    runs-on: "ubuntu-20.04"
+    container:
+      image: "${{ matrix.runner }}"
+    strategy:
+      matrix:
+        runner:
+          - "ubuntu:20.04"  # cmake 3.16, qt 5.12
+          - "ubuntu:20.10"  # cmake 3.16, qt 5.14
+    env:
+      DEBIAN_FRONTEND: noninteractive
+    steps:
+      - name: Show OS info
+        run: cat /etc/os-release
+      - uses: actions/checkout@v2
+      - name: Install qt and build tools
+        run: |
+          apt-get update &&
+          apt-get install -y --no-install-recommends \
+            g++ make cmake zlib1g-dev qt5-default qttools5-dev-tools
+      - name: Show cmake version
+        run: cmake --version
+      - name: Run cmake
+        run: cmake -S . -B build -DQUAZIP_ENABLE_TESTS=ON
+      - name: Build quazip
+        run: cd build && VERBOSE=1 make -j8
+      - name: Build tests
+        run: cd build/qztest && VERBOSE=1 make -j8
+      - name: Run tests
+        run: build/qztest/qztest
+
+  alpine:
+    name: "cmake on ${{ matrix.runner }}"
+    runs-on: "ubuntu-20.04"
+    container:
+      image: "${{ matrix.runner }}"
+    strategy:
+      matrix:
+        runner:
+          - "alpine:3.11"  # cmake 3.15, qt 5.12
+          - "alpine:3.12"  # cmake 3.17, qt 5.14
+    env:
+      DEBIAN_FRONTEND: noninteractive
+    steps:
+      - name: Show OS info
+        run: cat /etc/os-release
+      - uses: actions/checkout@v2
+      - name: Install qt and build tools
+        run: apk add --update g++ make cmake qt5-qtbase-dev
+      - name: Show cmake version
+        run: cmake --version
+      - name: Run cmake
+        run: cmake -S . -B build -DQUAZIP_ENABLE_TESTS=ON
+      - name: Build quazip
+        run: cd build && VERBOSE=1 make -j8
+      - name: Build tests
+        run: cd build/qztest && VERBOSE=1 make -j8
+      - name: Run tests
+        run: build/qztest/qztest


### PR DESCRIPTION
As mentioned in #104, here's a GitHub CI config that builds the library and runs tests for every PR or push to master.

Right now the following combinations are covered:

- Ubuntu 20.04, cmake 3.16, qt 5.12
- Ubuntu 20.10, cmake 3.16, qt 5.14
- Alpine Linux 3.11, cmake 3.15, qt 5.12
- Alpine Linux 3.12, cmake 3.17, qt 5.14

I did not find a distro that ships both Qt 4 and a cmake version >=3.15, so that couldn't be easily tested. But it should already ensure that a PR does not introduce changes that work on the latest version of cmake but break on 3.15.