### PR TITLE
fix: failed to decompress in some cases on linux platform

### DIFF
--- a/quazip/JlCompress.cpp
+++ b/quazip/JlCompress.cpp
@@ -392,7 +392,7 @@ QStringList JlCompress::extractDir(QuaZip &zip, const QString &dir)
         QString name = zip.getCurrentFileName();
         QString absFilePath = directory.absoluteFilePath(name);
         QString absCleanPath = QDir::cleanPath(absFilePath);
-        if (!absCleanPath.startsWith(absCleanDir + QLatin1String("/")))
+        if (!absCleanPath.startsWith(QDir::cleanPath(absCleanDir + QLatin1String("/"))))
             continue;
         if (!extractFile(&zip, QLatin1String(""), absFilePath)) {
             removeFile(extracted);


### PR DESCRIPTION
The working directory is the root directory. If you do not specify the decompression directory, the decompression will fail