### PR TITLE
CMake: Set default of `${QUAZIP_QT_MAJOR_VERSION}` to the Qt found

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,14 @@ option(BUILD_SHARED_LIBS "" ON)
 option(QUAZIP_INSTALL "" ON)
 option(QUAZIP_USE_QT_ZLIB "" OFF)
 option(QUAZIP_ENABLE_TESTS "Build QuaZip tests" OFF)
-set(QUAZIP_QT_MAJOR_VERSION 5 CACHE STRING "Qt version to use (4, 5 or 6), defaults to 5")
+
+find_package(
+  QT NAMES Qt6 Qt5 Qt4
+  COMPONENTS Core
+  REQUIRED
+)
+
+set(QUAZIP_QT_MAJOR_VERSION ${QT_VERSION_MAJOR} CACHE STRING "Qt version to use (4, 5 or 6), defaults to ${QT_VERSION_MAJOR}")
 
 if(NOT CMAKE_BUILD_TYPE)
 	set(CMAKE_BUILD_TYPE RELEASE)
@@ -51,6 +58,7 @@ else()
 	message(FATAL_ERROR "Qt version ${QUAZIP_QT_MAJOR_VERSION} is not supported")
 endif()
 
+message(STATUS "Using Qt version ${QUAZIP_QT_MAJOR_VERSION}")
 
 set(QUAZIP_QT_ZLIB_USED OFF)
 if(QUAZIP_USE_QT_ZLIB)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,11 +13,24 @@ option(QUAZIP_INSTALL "" ON)
 option(QUAZIP_USE_QT_ZLIB "" OFF)
 option(QUAZIP_ENABLE_TESTS "Build QuaZip tests" OFF)
 
+# Set the default value of `${QUAZIP_QT_MAJOR_VERSION}`.
+# We search quietly for Qt6, Qt5 and Qt4 in that order.
+# Qt6 and Qt5 provide config files for CMake.
+# Qt4 relies on `FindQt4.cmake`.
 find_package(
-  QT NAMES Qt6 Qt5 Qt4
-  COMPONENTS Core
-  REQUIRED
+  QT NAMES Qt6 Qt5
+  QUIET COMPONENTS Core
 )
+if (NOT QT_FOUND)
+  find_package(Qt4 QUIET COMPONENTS QtCore)
+  if (Qt4_FOUND)
+    set(QT_VERSION_MAJOR 4)
+  else()
+    # If neither 6, 5 nor 4 are found, we default to 5.
+    # The setup will fail further down.
+    set(QT_VERSION_MAJOR 5)
+  endif()
+endif()
 
 set(QUAZIP_QT_MAJOR_VERSION ${QT_VERSION_MAJOR} CACHE STRING "Qt version to use (4, 5 or 6), defaults to ${QT_VERSION_MAJOR}")
 

--- a/quazip/doc/index.dox
+++ b/quazip/doc/index.dox
@@ -104,11 +104,11 @@ same process, maybe with some CMake adjustments not specific to
 To build the library, run:
 \verbatim
 $ cd /wherever/quazip/source/is/quazip-x.y.z
-$ cmake -S . -B wherever/you/want/your/build/to/be -D QUAZIP_QT_MAJOR_VERSION=4, 5 or 6
+$ cmake -S . -B wherever/you/want/your/build/to/be -D QUAZIP_QT_MAJOR_VERSION=6, 5 or 4
 $ cmake --build wherever/you/want/your/build/to/be
 \endverbatim
 
-\c QUAZIP_QT_MAJOR_VERSION is just one number, and it defaults to 5, so if building with %Qt 5, it is optional.
+\c QUAZIP_QT_MAJOR_VERSION is just one number, and it defaults to the first Qt major version that can be found by CMake.
 
 On Windows, it may be required to use <tt>-G "MinGW Makefiles"</tt> or something like that to convince
 CMake that you really want to use, say, MinGW and not Visual Studio, for example.


### PR DESCRIPTION
Currently, the default value of `${QUAZIP_QT_MAJOR_VERSION}` is hard-
coded to 5.  If users want to use this package, they have to explicitly
set this variable, e.g. through `cmake .. -DQUAZIP_QT_MAJOR_VERSION=6`.

It would be better to detect the Qt version, that is installed on the
users system, and use that as the default.  This commit does exactly
that:

We search for either Qt6, Qt5 or Qt4 (in that order). If none is found,
we exit directly at that point.  If found, the major version is stored
in `${QT_VERSION_MAJOR}` which we subsequently use as the default value
for `${QUAZIP_QT_MAJOR_VERSION}`.


__Examples__:

No Qt installed:

`cmake -S .. -B .`
```
CMake Error at CMakeLists.txt:16 (find_package):
  Could not find a package configuration file provided by "QT" with any of
  the following names:

    Qt6Config.cmake
    qt6-config.cmake
    Qt5Config.cmake
    qt5-config.cmake
    Qt4Config.cmake
    qt4-config.cmake

  Add the installation prefix of "QT" to CMAKE_PREFIX_PATH or set "QT_DIR" to
  a directory containing one of the above files.  If "QT" provides a separate
  development package or SDK, be sure it has been installed.
```

Qt5 installed, but forced to be 6, which can't be found:

`cmake -S .. -B . -DQUAZIP_QT_MAJOR_VERSION=6`

```
CMake Error at CMakeLists.txt:40 (find_package):
  By not providing "FindQt6.cmake" in CMAKE_MODULE_PATH this project has
  asked CMake to find a package configuration file provided by "Qt6", but
  CMake did not find one.

  Could not find a package configuration file provided by "Qt6" with any of
  the following names:

    Qt6Config.cmake
    qt6-config.cmake

  Add the installation prefix of "Qt6" to CMAKE_PREFIX_PATH or set "Qt6_DIR"
  to a directory containing one of the above files.  If "Qt6" provides a
  separate development package or SDK, be sure it has been installed.

```

Qt5 installed on system, but 6 provided through `CMAKE_PREFIX_PATH`:

`cmake -S .. -B . -DCMAKE_PREFIX_PATH="$HOME/Qt/6.2.0/gcc_64"`

```
-- Using Qt version 6

```

IMHO, this change would make QuaZip easier to build as it would default
to the user's system.

Furthermore, debug output was added so that users can more easily
recognize what Qt version is used.