### PR TITLE
Expose all JlCompress methods

### DIFF
--- a/quazip/JlCompress.cpp
+++ b/quazip/JlCompress.cpp
@@ -25,7 +25,7 @@ see quazip/(un)zip.h files for details. Basically it's the zlib license.
 
 #include "JlCompress.h"
 
-static bool copyData(QIODevice &inFile, QIODevice &outFile)
+bool JlCompress::copyData(QIODevice &inFile, QIODevice &outFile)
 {
     while (!inFile.atEnd()) {
         char buf[4096];

--- a/quazip/JlCompress.h
+++ b/quazip/JlCompress.h
@@ -41,7 +41,8 @@ see quazip/(un)zip.h files for details. Basically it's the zlib license.
   simple operations, such as mass ZIP packing or extraction.
   */
 class QUAZIP_EXPORT JlCompress {
-private:
+public:
+    static bool copyData(QIODevice &inFile, QIODevice &outFile);
     static QStringList extractDir(QuaZip &zip, const QString &dir);
     static QStringList getFileList(QuaZip *zip);
     static QString extractFile(QuaZip &zip, QString fileName, QString fileDest);
@@ -81,7 +82,6 @@ private:
       */
     static bool removeFile(QStringList listFile);
 
-public:
     /// Compress a single file.
     /**
       \param fileCompressed The name of the archive.
@@ -126,7 +126,6 @@ public:
     static bool compressDir(QString fileCompressed, QString dir,
                             bool recursive, QDir::Filters filters);
 
-public:
     /// Extract a single file.
     /**
       \param fileCompressed The name of the archive.


### PR DESCRIPTION
[PolyMC](https://github.com/PolyMC/PolyMC) (and [MultiMC](https://github.com/MultiMC/Launcher)) use a modified version of QuaZip currently. I am currently working on removing old cruft like this. We utilize a few private methods of `JlCompress`, which are public in the modified version of QuaZip. I don't really see an issue in making it public here in upstream as well.

