### PR TITLE
Fix build with  QT_NO_CAST_FROM_ASCII defined

### DIFF
--- a/quazip/JlCompress.cpp
+++ b/quazip/JlCompress.cpp
@@ -384,8 +384,8 @@ QStringList JlCompress::extractDir(QuaZip &zip, const QString &dir)
     QString cleanDir = QDir::cleanPath(dir);
     QDir directory(cleanDir);
     QString absCleanDir = directory.absolutePath();
-    if (!absCleanDir.endsWith('/')) // It only ends with / if it's the FS root.
-        absCleanDir += '/';
+    if (!absCleanDir.endsWith(QLatin1Char('/'))) // It only ends with / if it's the FS root.
+        absCleanDir += QLatin1Char('/');
     QStringList extracted;
     if (!zip.goToFirstFile()) {
         return QStringList();


### PR DESCRIPTION
[QT_NO_CAST_FROM_ASCII ](https://doc.qt.io/qt-6/qstring.html#QT_NO_CAST_FROM_ASCII) is used to prevent occasional bugs with implicit conversion. 