### PR TITLE
minizip_crypt: fix warning

### DIFF
--- a/quazip/minizip_crypt.h
+++ b/quazip/minizip_crypt.h
@@ -90,13 +90,8 @@ static void init_keys(const char* passwd,unsigned long* pkeys,const z_crc_t FAR 
 #    define ZCR_SEED2 3141592654UL     /* use PI as default pattern */
 #  endif
 
-static int crypthead(passwd, buf, bufSize, pkeys, pcrc_32_tab, crcForCrypting)
-    const char *passwd;         /* password string */
-    unsigned char *buf;         /* where to write header */
-    int bufSize;
-    unsigned long* pkeys;
-    const z_crc_t FAR * pcrc_32_tab;
-    unsigned long crcForCrypting;
+static int crypthead(const char *passwd, unsigned char *buf, int bufSize,
+        unsigned long *pkeys, const z_crc_t FAR *pcrc_32_tab, unsigned long crcForCrypting)
 {
     int n;                       /* index in random header */
     int t;                       /* temporary */

--- a/quazip/quazip_qt_compat.h
+++ b/quazip/quazip_qt_compat.h
@@ -105,9 +105,16 @@ inline QString quazip_symlink_target(const QFileInfo &fi) {
 
 // this is not a deprecation but an improvement, for a change
 #include <QtCore/QDateTime>
+#if QT_VERSION >= QT_VERSION_CHECK(5, 2, 0)
+#include <QtCore/QTimeZone>
+#endif
 #if (QT_VERSION >= 0x040700)
 inline quint64 quazip_ntfs_ticks(const QDateTime &time, int fineTicks) {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
+    QDateTime base(QDate(1601, 1, 1), QTime(0, 0), QTimeZone::UTC);
+#else
     QDateTime base(QDate(1601, 1, 1), QTime(0, 0), Qt::UTC);
+#endif
     return base.msecsTo(time) * 10000 + fineTicks;
 }
 #else


### PR DESCRIPTION
```
In file included from ../../../RMEssentials/src/quazip/src/zip.c:199:
../../../RMEssentials/src/quazip/src/minizip_crypt.h:93:12: warning: a function declaration without a prototype is deprecated in all versions of C and is not supported in C2x [-Wdeprecated-non-prototype]
static int crypthead(passwd, buf, bufSize, pkeys, pcrc_32_tab, crcForCrypting)
           ^
```