### PR TITLE
From zlib: Reject overflows of zip header fields in minizip.

### DIFF
--- a/quazip/zip.c
+++ b/quazip/zip.c
@@ -1102,6 +1102,17 @@ extern int ZEXPORT zipOpenNewFileInZip4_64 (zipFile file, const char* filename, 
       return ZIP_PARAMERROR;
 #endif
 
+    // The filename and comment length must fit in 16 bits.
+    if ((filename!=NULL) && (strlen(filename)>0xffff))
+        return ZIP_PARAMERROR;
+    if ((comment!=NULL) && (strlen(comment)>0xffff))
+        return ZIP_PARAMERROR;
+    // The extra field length must fit in 16 bits. If the member also requires
+    // a Zip64 extra block, that will also need to fit within that 16-bit
+    // length, but that will be checked for later.
+    if ((size_extrafield_local>0xffff) || (size_extrafield_global>0xffff))
+        return ZIP_PARAMERROR;
+
     zi = (zip64_internal*)file;
 
     if (zi->in_opened_file_inzip == 1)


### PR DESCRIPTION
Quoting from the corresponding fixup in `zlib`:

> This checks the lengths of the file name, extra field, and comment that would be put in the zip headers, and rejects them if they are too long. They are each limited to 65535 bytes in length by the zip format. This also avoids possible buffer overflows if the provided fields are too long.