### PR TITLE
The internal Zlib module name changed again in Qt6.6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,9 +74,11 @@ set(QUAZIP_PACKAGE_NAME QuaZip-Qt${QUAZIP_QT_MAJOR_VERSION})
 if(QUAZIP_QT_MAJOR_VERSION EQUAL 6)
 	find_package(Qt6 REQUIRED COMPONENTS Core Core5Compat
                          OPTIONAL_COMPONENTS Network Test)
-  # Name of the Zlib component has been changed in 6.3.1
-  if(Qt6_VERSION VERSION_GREATER_EQUAL "6.3.1")
+  # Name of the Zlib component has been changed in 6.3.1, and again in 6.6.1...
+  if((Qt6_VERSION VERSION_GREATER_EQUAL "6.3.1") AND (Qt6_VERSION VERSION_LESS "6.6.1"))
     set(QUAZIP_QT_ZLIB_COMPONENT BundledZLIB)
+  elseif(Qt6_VERSION VERSION_GREATER_EQUAL "6.6.1")
+    set(QUAZIP_QT_ZLIB_COMPONENT ZlibPrivate)
   else()
     set(QUAZIP_QT_ZLIB_COMPONENT Zlib)
   endif()


### PR DESCRIPTION
They appear to have a hard time deciding what to name the poor thing, but this will make sure it builds with Qt6.6.1+.