### PR TITLE
Changes to QUAZIP_USE_QT_ZLIB

### DIFF
--- a/.github/docker/README.md
+++ b/.github/docker/README.md
@@ -1,0 +1,5 @@
+# Minimal Qt build images for CI
+
+These include minimal Qt built from source with `-qt-zlib` option to test `-DQUAZIP_USE_QT_ZLIB=ON` builds.
+
+`jurplel/install-qt-action` is essentially a binary downloader from Qt and does not have all options available.

--- a/.github/docker/qt-5.15.12/Dockerfile
+++ b/.github/docker/qt-5.15.12/Dockerfile
@@ -1,0 +1,65 @@
+FROM ubuntu:22.04 as builder
+
+WORKDIR /build
+
+RUN apt-get -y update && apt-get -y install build-essential cmake tar wget python3
+
+RUN wget -qO- https://ftp.fau.de/qtproject/archive/qt/5.15/5.15.12/single/qt-everywhere-opensource-src-5.15.12.tar.xz | tar xJ
+
+RUN qt-everywhere-src-5.15.12/configure -qt-zlib \
+-shared \
+-opensource \
+-confirm-license \
+-optimize-size \
+-nomake examples \
+-nomake tests \
+-no-dbus \
+-no-icu \
+-no-fontconfig \
+-no-opengl \
+-no-openssl \
+-no-gui \
+-skip qtconnectivity \
+-skip qtdatavis3d \
+-skip qtdeclarative \
+-skip qtdoc \
+-skip qtactiveqt \
+-skip qt3d \
+-skip qtimageformats \
+-skip qtlocation \
+-skip qtmultimedia \
+-skip qtopcua \
+-skip qtremoteobjects \
+-skip qtscxml \
+-skip qtsensors \
+-skip qtserialbus \
+-skip qtserialport \
+-skip qtspeech \
+-skip qtsvg \
+-skip qttools \
+-skip qttranslations \
+-skip qtwebchannel \
+-skip qtwebengine \
+-skip qtwebsockets \
+-skip qtwebview \
+-skip qtcharts \
+-skip qtcoap \
+-skip qtlottie \
+-skip qtmqtt \
+-skip qtnetworkauth \
+-skip qtquick3d \
+-skip qtquicktimeline \
+-skip qtvirtualkeyboard \
+-skip qtwayland \
+-skip qtcanvas3d \
+-skip qtgamepad \
+-skip qtpurchasing \
+-skip qtscript
+
+RUN make -j$(nproc) && make install
+
+FROM ubuntu:22.04
+
+RUN apt-get -y update && apt-get -y install build-essential cmake
+
+COPY --from=builder /usr/local/Qt-5.15.12 /usr/local/Qt-5.15.12

--- a/.github/docker/qt-6.4.3/Dockerfile
+++ b/.github/docker/qt-6.4.3/Dockerfile
@@ -1,0 +1,73 @@
+FROM ubuntu:22.04 AS builder
+
+WORKDIR /build
+
+RUN apt-get -y update && apt-get -y install build-essential cmake tar wget python3
+
+RUN wget -qO- https://ftp.fau.de/qtproject/archive/qt/6.4/6.4.3/single/qt-everywhere-src-6.4.3.tar.xz | tar xJ
+
+RUN qt-everywhere-src-6.4.3/configure -qt-zlib \
+-shared \
+-opensource \
+-confirm-license \
+-optimize-size \
+-nomake examples \
+-nomake tests \
+-no-dbus \
+-no-icu \
+-no-fontconfig \
+-no-opengl \
+-no-openssl \
+-no-gui \
+-skip qtconnectivity \
+-skip qtdatavis3d \
+-skip qtdeclarative \
+-skip qtdoc \
+-skip qtactiveqt \
+-skip qt3d \
+-skip qtgraphs \
+-skip qtgrpc \
+-skip qtimageformats \
+-skip qtlanguageserver \
+-skip qtlocation \
+-skip qthttpserver \
+-skip qtmultimedia \
+-skip qtopcua \
+-skip qtpositioning \
+-skip qtremoteobjects \
+-skip qtscxml \
+-skip qtsensors \
+-skip qtserialbus \
+-skip qtserialport \
+-skip qtshadertools \
+-skip qtspeech \
+-skip qtsvg \
+-skip qttools \
+-skip qttranslations \
+-skip qtwebchannel \
+-skip qtwebengine \
+-skip qtwebsockets \
+-skip qtwebview \
+-skip qtcharts \
+-skip qtcoap \
+-skip qtlottie \
+-skip qtmqtt \
+-skip qtnetworkauth \
+-skip qtquick3d \
+-skip qtquick3dphysics \
+-skip qtquickeffectmaker \
+-skip qtquicktimeline \
+-skip qtvirtualkeyboard \
+-skip qtwayland \
+-skip qtcanvas3d \
+-skip qtgamepad \
+-skip qtpurchasing \
+-skip qtscript
+
+RUN cmake --build . --parallel --target install
+
+FROM ubuntu:22.04
+
+RUN apt-get -y update && apt-get -y install build-essential cmake
+
+COPY --from=builder /usr/local/Qt-6.4.3 /usr/local/Qt-6.4.3

--- a/.github/docker/qt-6.6.2/Dockerfile
+++ b/.github/docker/qt-6.6.2/Dockerfile
@@ -1,0 +1,73 @@
+FROM ubuntu:22.04 as builder
+
+WORKDIR /build
+
+RUN apt-get -y update && apt-get -y install build-essential cmake tar wget python3
+
+RUN wget -qO- https://ftp.fau.de/qtproject/archive/qt/6.6/6.6.2/single/qt-everywhere-src-6.6.2.tar.xz | tar xJ
+
+RUN qt-everywhere-src-6.6.2/configure -qt-zlib \
+-shared \
+-opensource \
+-confirm-license \
+-optimize-size \
+-nomake examples \
+-nomake tests \
+-no-dbus \
+-no-icu \
+-no-fontconfig \
+-no-opengl \
+-no-openssl \
+-no-gui \
+-skip qtconnectivity \
+-skip qtdatavis3d \
+-skip qtdeclarative \
+-skip qtdoc \
+-skip qtactiveqt \
+-skip qt3d \
+-skip qtgraphs \
+-skip qtgrpc \
+-skip qtimageformats \
+-skip qtlanguageserver \
+-skip qtlocation \
+-skip qthttpserver \
+-skip qtmultimedia \
+-skip qtopcua \
+-skip qtpositioning \
+-skip qtremoteobjects \
+-skip qtscxml \
+-skip qtsensors \
+-skip qtserialbus \
+-skip qtserialport \
+-skip qtshadertools \
+-skip qtspeech \
+-skip qtsvg \
+-skip qttools \
+-skip qttranslations \
+-skip qtwebchannel \
+-skip qtwebengine \
+-skip qtwebsockets \
+-skip qtwebview \
+-skip qtcharts \
+-skip qtcoap \
+-skip qtlottie \
+-skip qtmqtt \
+-skip qtnetworkauth \
+-skip qtquick3d \
+-skip qtquick3dphysics \
+-skip qtquickeffectmaker \
+-skip qtquicktimeline \
+-skip qtvirtualkeyboard \
+-skip qtwayland \
+-skip qtcanvas3d \
+-skip qtgamepad \
+-skip qtpurchasing \
+-skip qtscript
+
+RUN cmake --build . --parallel --target install
+
+FROM ubuntu:22.04
+
+RUN apt-get -y update && apt-get -y install build-essential cmake
+
+COPY --from=builder /usr/local/Qt-6.6.2 /usr/local/Qt-6.6.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         ubuntu_version: [20.04, 22.04]
-        qt_version: [5.12.12, 5.15.2, 6.4.0, 6.6.2]
+        qt_version: [5.12.12, 5.15.2, 6.6.2]
         shared: [ON, OFF]
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         ubuntu_version: [20.04, 22.04]
-        qt_version: [5.12.12, 5.15.2, 6.4.0, 6.6.1]
+        qt_version: [5.12.12, 5.15.2, 6.4.0, 6.6.2]
         shared: [ON, OFF]
 
     steps:
@@ -107,7 +107,7 @@ jobs:
       fail-fast: false
       matrix:
         macos_version: [11, 12]
-        qt_version: [5.15.12, 6.4.0]
+        qt_version: [5.15.2, 6.6.2]
         shared: [ON, OFF]
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ on:
   push:
     branches:
       - master
+      - feature/*
   pull_request:
 
 name: CI
@@ -12,19 +13,20 @@ env:
 
 jobs:
 
-  build:
+  ubuntu:
+    if: true
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
     name: Ubuntu-${{ matrix.ubuntu_version }}-Qt-${{ matrix.qt_version }}-shared-${{ matrix.shared }}
     strategy:
       fail-fast: false
       matrix:
         ubuntu_version: [20.04, 22.04]
-        qt_version: [5.12.12, 5.15.2, 6.4.0]
+        qt_version: [5.12.12, 5.15.2, 6.4.0, 6.6.1]
         shared: [ON, OFF]
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
                 
     - name: Install Qt6
       if: "startsWith(matrix.qt_version, '6.')"
@@ -61,19 +63,56 @@ jobs:
       working-directory: ${{github.workspace}}/build
       run: "ctest --verbose"
 
+  use-qt-zlib:
+    if: true
+    runs-on: ubuntu-22.04
+    name: Qt-${{ matrix.qt_version }}-tests-${{ matrix.enable_tests }}
+    container: ghcr.io/cen1/qt:${{ matrix.qt_version }}
+    strategy:
+      fail-fast: false
+      matrix:
+        enable_tests: [ ON, OFF ]
+        qt_version: [ 5.15.12, 6.4.3, 6.6.2 ]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure CMake
+        if: matrix.enable_tests == 'ON' && startsWith(matrix.qt_version, '6')
+        continue-on-error: true
+        run: cmake -DCMAKE_BUILD_TYPE="${{env.BUILD_TYPE}}" -DBUILD_SHARED_LIBS=ON -DQUAZIP_ENABLE_TESTS=${{ matrix.enable_tests }} -DQUAZIP_USE_QT_ZLIB=ON -DCMAKE_PREFIX_PATH="/usr/local/Qt-${{ matrix.qt_version }}" -B "${{github.workspace}}/build"
+        id: qt6_cmake_tests_on
+
+      - name: Configure CMake
+        if: matrix.enable_tests == 'ON' && startsWith(matrix.qt_version, '5')
+        continue-on-error: false
+        run: cmake -DCMAKE_BUILD_TYPE="${{env.BUILD_TYPE}}" -DBUILD_SHARED_LIBS=ON -DQUAZIP_ENABLE_TESTS=${{ matrix.enable_tests }} -DQUAZIP_USE_QT_ZLIB=ON -DCMAKE_PREFIX_PATH="/usr/local/Qt-${{ matrix.qt_version }}" -B "${{github.workspace}}/build"
+        id: qt5_cmake_tests_on
+
+      - name: Configure CMake
+        if: matrix.enable_tests == 'OFF'
+        run: cmake -DCMAKE_BUILD_TYPE="${{env.BUILD_TYPE}}" -DBUILD_SHARED_LIBS=ON -DQUAZIP_ENABLE_TESTS=${{ matrix.enable_tests }} -DQUAZIP_USE_QT_ZLIB=ON -DCMAKE_PREFIX_PATH="/usr/local/Qt-${{ matrix.qt_version }}" -B "${{github.workspace}}/build"
+        id: cmake_tests_off
+
+      - name: Build
+        if: steps.cmake_tests_off.outcome == 'success' || steps.qt5_cmake_tests_on.outcome == 'success'
+        run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+
   macos:
+    if: true
     runs-on: macos-${{ matrix.macos_version }}
     name: macos-${{ matrix.macos_version }}-Qt-${{ matrix.qt_version }}-shared-${{ matrix.shared }}
     strategy:
       fail-fast: false
       matrix:
         macos_version: [11, 12]
-        qt_version: [5.15.2, 6.4.0]
+        qt_version: [5.15.12, 6.4.0]
         shared: [ON, OFF]
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install Qt6
         if: "startsWith(matrix.qt_version, '6.')"
@@ -105,6 +144,7 @@ jobs:
         run: "ctest --verbose"
 
   alpine:
+    if: true
     name: "cmake on ${{ matrix.runner }}"
     runs-on: "ubuntu-20.04"
     container:
@@ -119,7 +159,7 @@ jobs:
     steps:
       - name: Show OS info
         run: cat /etc/os-release
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Install qt and build tools
         run: apk add --update g++ make cmake qt5-qtbase-dev
       - name: Show cmake version

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 *.tags
 *.user
 *.swp
+.idea/
+cmake-*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,7 +72,7 @@ set(QUAZIP_DIR_NAME QuaZip-Qt${QUAZIP_QT_MAJOR_VERSION}-${QUAZIP_LIB_VERSION})
 set(QUAZIP_PACKAGE_NAME QuaZip-Qt${QUAZIP_QT_MAJOR_VERSION})
 
 if(QUAZIP_QT_MAJOR_VERSION EQUAL 6)
-	find_package(Qt6 REQUIRED COMPONENTS Core Core5Compat
+  find_package(Qt6 REQUIRED COMPONENTS Core Core5Compat
                          OPTIONAL_COMPONENTS Network Test)
   message(STATUS "Found Qt version ${Qt6_VERSION} at ${Qt6_DIR}")
   # Name of the Zlib component appears to be ZlibPrivate, tested Qt versions 6.3.1 to 6.6.2
@@ -89,8 +89,9 @@ if(QUAZIP_QT_MAJOR_VERSION EQUAL 6)
 	set(QUAZIP_TEST_QT_LIBRARIES Qt6::Core Qt6::Core5Compat Qt6::Network Qt6::Test)
 	set(QUAZIP_PKGCONFIG_REQUIRES "zlib, Qt6Core")
 elseif(QUAZIP_QT_MAJOR_VERSION EQUAL 5)
-	find_package(Qt5 REQUIRED COMPONENTS Core
+  find_package(Qt5 REQUIRED COMPONENTS Core
                          OPTIONAL_COMPONENTS Network Test)
+  message(STATUS "Found Qt version ${Qt5_VERSION} at ${Qt5_DIR}")
   set(QUAZIP_QT_ZLIB_COMPONENT Zlib)
 	set(QUAZIP_LIB_LIBRARIES Qt5::Core)
 	set(QUAZIP_TEST_QT_LIBRARIES Qt5::Core Qt5::Network Qt5::Test)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,11 +74,14 @@ set(QUAZIP_PACKAGE_NAME QuaZip-Qt${QUAZIP_QT_MAJOR_VERSION})
 if(QUAZIP_QT_MAJOR_VERSION EQUAL 6)
 	find_package(Qt6 REQUIRED COMPONENTS Core Core5Compat
                          OPTIONAL_COMPONENTS Network Test)
-  # Name of the Zlib component has been changed in 6.3.1, and again in 6.6.1...
-  if((Qt6_VERSION VERSION_GREATER_EQUAL "6.3.1") AND (Qt6_VERSION VERSION_LESS "6.6.1"))
-    set(QUAZIP_QT_ZLIB_COMPONENT BundledZLIB)
-  elseif(Qt6_VERSION VERSION_GREATER_EQUAL "6.6.1")
+  message(STATUS "Found Qt version ${Qt6_VERSION} at ${Qt6_DIR}")
+  # Name of the Zlib component appears to be ZlibPrivate, tested Qt versions 6.3.1 to 6.6.2
+  # BundledZLIB fails with: Failed to find Qt component "BundledZLIB". Expected Config file at
+  # "/path/to/Qt6/qtbase/lib/cmake/Qt6BundledZLIB/Qt6BundledZLIBConfig.cmake" does NOT exist
+  if((Qt6_VERSION VERSION_GREATER_EQUAL "6.3.1"))
     set(QUAZIP_QT_ZLIB_COMPONENT ZlibPrivate)
+    # ZlibPrivate seems to expose headers only so tests fail to link.
+    set(QUAZIP_QT_ZLIB_COMPONENT_INCOMPATIBLE_TESTS ON)
   else()
     set(QUAZIP_QT_ZLIB_COMPONENT Zlib)
   endif()
@@ -109,8 +112,11 @@ set(QUAZIP_QT_ZLIB_USED OFF)
 if(QUAZIP_USE_QT_ZLIB)
     find_package(Qt${QUAZIP_QT_MAJOR_VERSION} OPTIONAL_COMPONENTS ${QUAZIP_QT_ZLIB_COMPONENT})
     if(Qt${QUAZIP_QT_MAJOR_VERSION}${QUAZIP_QT_ZLIB_COMPONENT}_FOUND)
+        message(STATUS "Qt component ${QUAZIP_QT_ZLIB_COMPONENT} found")
         set(QUAZIP_LIB_LIBRARIES ${QUAZIP_LIB_LIBRARIES} Qt${QUAZIP_QT_MAJOR_VERSION}::${QUAZIP_QT_ZLIB_COMPONENT})
         set(QUAZIP_QT_ZLIB_USED ON)
+    else()
+        message(FATAL_ERROR "QUAZIP_USE_QT_ZLIB was set but bundled zlib was not found. Terminating to prevent accidental linking to system libraries.")
     endif()
 endif()
 
@@ -208,6 +214,9 @@ endif()
 add_subdirectory(quazip)
 
 if(QUAZIP_ENABLE_TESTS)
+    if(QUAZIP_QT_ZLIB_USED AND QUAZIP_QT_ZLIB_COMPONENT_INCOMPATIBLE_TESTS)
+        message(FATAL_ERROR "QUAZIP_ENABLE_TESTS with QUAZIP_USE_QT_ZLIB is incompatible with this Qt version. You need to provide system zlib.")
+    endif()
     message(STATUS "Building QuaZip tests")
     enable_testing()
     add_subdirectory(qztest)

--- a/qztest/CMakeLists.txt
+++ b/qztest/CMakeLists.txt
@@ -24,6 +24,7 @@ set(QZTEST_SOURCES
 add_executable(qztest ${QZTEST_SOURCES} qztest.qrc)
 set_target_properties(qztest PROPERTIES AUTORCC ON)
 target_include_directories(qztest PRIVATE ${QUAZIP_INC})
+
 target_link_libraries(qztest
     ${QUAZIP_TEST_QT_LIBRARIES}
     QuaZip::QuaZip


### PR DESCRIPTION
After testing versions from 6.3.1 up to 6.6.2 and latest patch versions in between compiled with `-qt-zlib` , I could not get `BundledZlib` to work as a component name.
All versions throw an error:
```
 Failed to find Qt component "BundledZLIB". Expected Config file at
  # "/path/to/Qt6/qtbase/lib/cmake/Qt6BundledZLIB/Qt6BundledZLIBConfig.cmake" does NOT exist 
```
The only name that works is `ZlibPrivate` because there is a Qt6ZlibPrivate CMake target. I did not test Versions 6.2, 6.1 and 6.0 because they don't compile on Debian 12.

The name was introduced in https://github.com/stachenov/quazip/pull/171 so maybe @aikawayataro has some insights how that worked. This is an example how my tests were done : https://github.com/cen1/quazip/actions/runs/8131704060/job/22221334441

Additional observations are that `libQt6BundledZLIB.a` exists in Qt installations but `ZlibPrivate` only exports headers, not this library. I suspect Qt just does not want anyone to use it so they excluded it from CMake. If I explicitely linked to that I could get tests to compile but I really do not like hacking like this.