### PR TITLE
Removing the dependency of the Core5Compat module with Qt6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -230,14 +230,24 @@ if(QUAZIP_BZIP2)
 endif()
 
 #issue Qt5/Qt6 / Core5Compat and QTextCodec
+
+
 if(${QT_VERSION} VERSION_GREATER_EQUAL 6.0.0)
+
+    find_package(Qt6 OPTIONAL_COMPONENTS  Core5Compat)
+
   if(Qt6Core5Compat_FOUND)
+        set(QUAZIP_LIB_LIBRARIES ${QUAZIP_LIB_LIBRARIES} Qt6::Core5Compat)
+        set(QUAZIP_TEST_QT_LIBRARIES ${QUAZIP_TEST_QT_LIBRARIES} Qt6::Core5Compat)
+  
     add_compile_definitions( QUAZIP_CAN_USE_QTEXTCODEC)
+     message(-- Quazip use QTextCodec)
+    
   endif()
 else()
     add_compile_definitions( QUAZIP_CAN_USE_QTEXTCODEC)
+     message(-- Quazip use QTextCodec)
 endif()
-
 
 
 add_subdirectory(quazip)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,10 @@ if (NOT QT_FOUND)
   endif()
 endif()
 
+
+
+
+
 set(QUAZIP_QT_MAJOR_VERSION ${QT_VERSION_MAJOR} CACHE STRING "Qt version to use (4, 5 or 6), defaults to ${QT_VERSION_MAJOR}")
 
 if (QUAZIP_QT_MAJOR_VERSION EQUAL 6)
@@ -63,7 +67,7 @@ else()
 endif()
 
 if(NOT CMAKE_BUILD_TYPE)
-	set(CMAKE_BUILD_TYPE RELEASE)
+    set(CMAKE_BUILD_TYPE RELEASE)
 endif()
 
 set(CMAKE_AUTOMOC ON)
@@ -102,7 +106,7 @@ elseif(QUAZIP_QT_MAJOR_VERSION EQUAL 4)
     set(QUAZIP_TEST_QT_LIBRARIES Qt4::QtCore Qt4::QtNetwork Qt4::QtTest)
     set(QUAZIP_PKGCONFIG_REQUIRES "zlib, QtCore")
 else()
-	message(FATAL_ERROR "Qt version ${QUAZIP_QT_MAJOR_VERSION} is not supported")
+    message(FATAL_ERROR "Qt version ${QUAZIP_QT_MAJOR_VERSION} is not supported")
 endif()
 
 message(STATUS "Using Qt version ${QUAZIP_QT_MAJOR_VERSION}")
@@ -224,6 +228,17 @@ if(QUAZIP_BZIP2)
         add_compile_definitions(HAVE_BZIP2)
     endif()
 endif()
+
+#issue Qt5/Qt6 / Core5Compat and QTextCodec
+if(${QT_VERSION} VERSION_GREATER_EQUAL 6.0.0)
+  if(Qt6Core5Compat_FOUND)
+    add_compile_definitions( QUAZIP_CAN_USE_QTEXTCODEC)
+  endif()
+else()
+    add_compile_definitions( QUAZIP_CAN_USE_QTEXTCODEC)
+endif()
+
+
 
 add_subdirectory(quazip)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -241,12 +241,12 @@ if(${QT_VERSION} VERSION_GREATER_EQUAL 6.0.0)
         set(QUAZIP_TEST_QT_LIBRARIES ${QUAZIP_TEST_QT_LIBRARIES} Qt6::Core5Compat)
   
     add_compile_definitions( QUAZIP_CAN_USE_QTEXTCODEC)
-     message(-- Quazip use QTextCodec)
+     message("-- Quazip use QTextCodec")
     
   endif()
 else()
     add_compile_definitions( QUAZIP_CAN_USE_QTEXTCODEC)
-     message(-- Quazip use QTextCodec)
+     message("-- Quazip use QTextCodec")
 endif()
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,13 +78,13 @@ set(QUAZIP_DIR_NAME QuaZip-Qt${QUAZIP_QT_MAJOR_VERSION}-${QUAZIP_LIB_VERSION})
 set(QUAZIP_PACKAGE_NAME QuaZip-Qt${QUAZIP_QT_MAJOR_VERSION})
 
 if(QUAZIP_QT_MAJOR_VERSION EQUAL 6)
-    find_package(Qt6 REQUIRED COMPONENTS Core Core5Compat
+    find_package(Qt6 REQUIRED COMPONENTS Core 
             OPTIONAL_COMPONENTS Network Test)
     message(STATUS "Found Qt version ${Qt6_VERSION} at ${Qt6_DIR}")
     set(QUAZIP_QT_ZLIB_COMPONENT BundledZLIB)
     set(QUAZIP_QT_ZLIB_HEADER_COMPONENT ZlibPrivate)
-    set(QUAZIP_LIB_LIBRARIES Qt6::Core Qt6::Core5Compat)
-    set(QUAZIP_TEST_QT_LIBRARIES Qt6::Core Qt6::Core5Compat Qt6::Network Qt6::Test)
+    set(QUAZIP_LIB_LIBRARIES Qt6::Core )
+    set(QUAZIP_TEST_QT_LIBRARIES Qt6::Core Qt6::Network Qt6::Test)
     set(QUAZIP_PKGCONFIG_REQUIRES "zlib, Qt6Core")
 elseif(QUAZIP_QT_MAJOR_VERSION EQUAL 5)
     find_package(Qt5 REQUIRED COMPONENTS Core

--- a/quazip/CMakeLists.txt
+++ b/quazip/CMakeLists.txt
@@ -16,6 +16,9 @@ set(QUAZIP_HEADERS
         quazip.h
         quazip_global.h
         quazip_qt_compat.h
+
+        quazip_textcodec.h
+
         quazipdir.h
         quazipfile.h
         quazipfileinfo.h
@@ -36,6 +39,9 @@ set(QUAZIP_SOURCES
         quagzipfile.cpp
         quaziodevice.cpp
         quazip.cpp
+
+        quazip_textcodec.cpp
+
         quazipdir.cpp
         quazipfile.cpp
         quazipfileinfo.cpp

--- a/quazip/JlCompress.cpp
+++ b/quazip/JlCompress.cpp
@@ -358,7 +358,7 @@ QStringList JlCompress::extractFiles(QuaZip &zip, const QStringList &files, cons
     return extracted;
 }
 
-QStringList JlCompress::extractDir(QString fileCompressed, QTextCodec* fileNameCodec, QString dir) {
+QStringList JlCompress::extractDir(QString fileCompressed, QuazipTextCodec* fileNameCodec, QString dir) {
     // Apro lo zip
     QuaZip zip(fileCompressed);
     if (fileNameCodec)
@@ -442,7 +442,7 @@ QStringList JlCompress::getFileList(QuaZip *zip)
     return lst;
 }
 
-QStringList JlCompress::extractDir(QIODevice* ioDevice, QTextCodec* fileNameCodec, QString dir)
+QStringList JlCompress::extractDir(QIODevice* ioDevice, QuazipTextCodec* fileNameCodec, QString dir)
 {
     QuaZip zip(ioDevice);
     if (fileNameCodec)

--- a/quazip/JlCompress.h
+++ b/quazip/JlCompress.h
@@ -160,7 +160,7 @@ public:
       left empty.
       \return The list of the full paths of the files extracted, empty on failure.
       */
-    static QStringList extractDir(QString fileCompressed, QTextCodec* fileNameCodec, QString dir = QString());
+    static QStringList extractDir(QString fileCompressed, QuazipTextCodec* fileNameCodec, QString dir = QString());
     /// Get the file list.
     /**
       \return The list of the files in the archive, or, more precisely, the
@@ -202,7 +202,7 @@ public:
       left empty.
       \return The list of the full paths of the files extracted, empty on failure.
       */
-    static QStringList extractDir(QIODevice* ioDevice, QTextCodec* fileNameCodec, QString dir = QString());
+    static QStringList extractDir(QIODevice* ioDevice, QuazipTextCodec* fileNameCodec, QString dir = QString());
     /// Get the file list.
     /**
       \return The list of the files in the archive, or, more precisely, the

--- a/quazip/quaziodevice.cpp
+++ b/quazip/quaziodevice.cpp
@@ -239,11 +239,11 @@ qint64 QuaZIODevice::readData(char *data, qint64 maxSize)
       switch (inflate(&d->zins, Z_SYNC_FLUSH)) {
       case Z_OK:
         read = reinterpret_cast<char *>(d->zins.next_out) - data;
-        d->inBufPos = reinterpret_cast<char *>(d->zins.next_in) - d->inBuf;
+        d->inBufPos = reinterpret_cast<z_const char *>(d->zins.next_in) - d->inBuf;
         break;
       case Z_STREAM_END:
         read = reinterpret_cast<char *>(d->zins.next_out) - data;
-        d->inBufPos = reinterpret_cast<char *>(d->zins.next_in) - d->inBuf;
+        d->inBufPos = reinterpret_cast<z_const char *>(d->zins.next_in) - d->inBuf;
         d->atEnd = true;
         return read;
       case Z_BUF_ERROR: // this should never happen, but just in case
@@ -294,7 +294,7 @@ qint64 QuaZIODevice::writeData(const char *data, qint64 maxSize)
     d->zouts.avail_out = QUAZIO_OUTBUFSIZE;
     switch (deflate(&d->zouts, Z_NO_FLUSH)) {
     case Z_OK:
-      written = reinterpret_cast<char *>(d->zouts.next_in) - data;
+      written = reinterpret_cast<z_const char *>(d->zouts.next_in) - data;
       d->outBufSize = reinterpret_cast<char *>(d->zouts.next_out) - d->outBuf;
       break;
     default:

--- a/quazip/quaziodevice.cpp
+++ b/quazip/quaziodevice.cpp
@@ -239,11 +239,11 @@ qint64 QuaZIODevice::readData(char *data, qint64 maxSize)
       switch (inflate(&d->zins, Z_SYNC_FLUSH)) {
       case Z_OK:
         read = reinterpret_cast<char *>(d->zins.next_out) - data;
-        d->inBufPos = reinterpret_cast<z_const char *>(d->zins.next_in) - d->inBuf;
+        d->inBufPos = reinterpret_cast<char *>(d->zins.next_in) - d->inBuf;
         break;
       case Z_STREAM_END:
         read = reinterpret_cast<char *>(d->zins.next_out) - data;
-        d->inBufPos = reinterpret_cast<z_const char *>(d->zins.next_in) - d->inBuf;
+        d->inBufPos = reinterpret_cast<char *>(d->zins.next_in) - d->inBuf;
         d->atEnd = true;
         return read;
       case Z_BUF_ERROR: // this should never happen, but just in case
@@ -294,7 +294,7 @@ qint64 QuaZIODevice::writeData(const char *data, qint64 maxSize)
     d->zouts.avail_out = QUAZIO_OUTBUFSIZE;
     switch (deflate(&d->zouts, Z_NO_FLUSH)) {
     case Z_OK:
-      written = reinterpret_cast<z_const char *>(d->zouts.next_in) - data;
+      written = reinterpret_cast<char *>(d->zouts.next_in) - data;
       d->outBufSize = reinterpret_cast<char *>(d->zouts.next_out) - d->outBuf;
       break;
     default:

--- a/quazip/quazip.cpp
+++ b/quazip/quazip.cpp
@@ -45,9 +45,9 @@ class QuaZipPrivate {
     /// The pointer to the corresponding QuaZip instance.
     QuaZip *q;
     /// The codec for file names (used when UTF-8 is not enabled).
-    QTextCodec *fileNameCodec;
+    QuazipTextCodec *fileNameCodec;
     /// The codec for comments (used when UTF-8 is not enabled).
-    QTextCodec *commentCodec;
+    QuazipTextCodec *commentCodec;
     /// The archive file name.
     QString zipName;
     /// The device to access the archive.
@@ -76,10 +76,10 @@ class QuaZipPrivate {
     bool utf8;
     /// The OS code.
     uint osCode;
-    inline QTextCodec *getDefaultFileNameCodec()
+    inline QuazipTextCodec *getDefaultFileNameCodec()
     {
         if (defaultFileNameCodec == nullptr) {
-          return QTextCodec::codecForLocale();
+          return QuazipTextCodec::codecForLocale();
         }
         return defaultFileNameCodec;
     }
@@ -87,7 +87,7 @@ class QuaZipPrivate {
     inline QuaZipPrivate(QuaZip *q):
       q(q),
       fileNameCodec(getDefaultFileNameCodec()),
-      commentCodec(QTextCodec::codecForLocale()),
+      commentCodec(QuazipTextCodec::codecForLocale()),
       ioDevice(nullptr),
       mode(QuaZip::mdNotOpen),
       hasCurrentFile_f(false),
@@ -107,7 +107,7 @@ class QuaZipPrivate {
     inline QuaZipPrivate(QuaZip *q, const QString &zipName):
       q(q),
       fileNameCodec(getDefaultFileNameCodec()),
-      commentCodec(QTextCodec::codecForLocale()),
+      commentCodec(QuazipTextCodec::codecForLocale()),
       zipName(zipName),
       ioDevice(nullptr),
       mode(QuaZip::mdNotOpen),
@@ -128,7 +128,7 @@ class QuaZipPrivate {
     inline QuaZipPrivate(QuaZip *q, QIODevice *ioDevice):
       q(q),
       fileNameCodec(getDefaultFileNameCodec()),
-      commentCodec(QTextCodec::codecForLocale()),
+      commentCodec(QuazipTextCodec::codecForLocale()),
       ioDevice(ioDevice),
       mode(QuaZip::mdNotOpen),
       hasCurrentFile_f(false),
@@ -155,11 +155,11 @@ class QuaZipPrivate {
       QHash<QString, unz64_file_pos> directoryCaseSensitive;
       QHash<QString, unz64_file_pos> directoryCaseInsensitive;
       unz64_file_pos lastMappedDirectoryEntry;
-      static QTextCodec *defaultFileNameCodec;
+      static QuazipTextCodec *defaultFileNameCodec;
       static uint defaultOsCode;
 };
 
-QTextCodec *QuaZipPrivate::defaultFileNameCodec = nullptr;
+QuazipTextCodec *QuaZipPrivate::defaultFileNameCodec = nullptr;
 uint QuaZipPrivate::defaultOsCode = QUAZIP_OS_UNIX;
 
 void QuaZipPrivate::clearDirectoryMap()
@@ -588,14 +588,14 @@ QString QuaZip::getCurrentFileName()const
   return result;
 }
 
-void QuaZip::setFileNameCodec(QTextCodec *fileNameCodec)
+void QuaZip::setFileNameCodec(QuazipTextCodec *fileNameCodec)
 {
   p->fileNameCodec=fileNameCodec;
 }
 
 void QuaZip::setFileNameCodec(const char *fileNameCodecName)
 {
-    p->fileNameCodec=QTextCodec::codecForName(fileNameCodecName);
+    p->fileNameCodec=QuazipTextCodec::codecForName(fileNameCodecName);
 }
 
 void QuaZip::setOsCode(uint osCode)
@@ -608,22 +608,22 @@ uint QuaZip::getOsCode() const
     return p->osCode;
 }
 
-QTextCodec *QuaZip::getFileNameCodec()const
+QuazipTextCodec *QuaZip::getFileNameCodec()const
 {
   return p->fileNameCodec;
 }
 
-void QuaZip::setCommentCodec(QTextCodec *commentCodec)
+void QuaZip::setCommentCodec(QuazipTextCodec *commentCodec)
 {
   p->commentCodec=commentCodec;
 }
 
 void QuaZip::setCommentCodec(const char *commentCodecName)
 {
-  p->commentCodec=QTextCodec::codecForName(commentCodecName);
+  p->commentCodec=QuazipTextCodec::codecForName(commentCodecName);
 }
 
-QTextCodec *QuaZip::getCommentCodec()const
+QuazipTextCodec *QuaZip::getCommentCodec()const
 {
   return p->commentCodec;
 }
@@ -783,14 +783,14 @@ Qt::CaseSensitivity QuaZip::convertCaseSensitivity(QuaZip::CaseSensitivity cs)
   }
 }
 
-void QuaZip::setDefaultFileNameCodec(QTextCodec *codec)
+void QuaZip::setDefaultFileNameCodec(QuazipTextCodec *codec)
 {
     QuaZipPrivate::defaultFileNameCodec = codec;
 }
 
 void QuaZip::setDefaultFileNameCodec(const char *codecName)
 {
-    setDefaultFileNameCodec(QTextCodec::codecForName(codecName));
+    setDefaultFileNameCodec(QuazipTextCodec::codecForName(codecName));
 }
 
 void QuaZip::setDefaultOsCode(uint osCode)

--- a/quazip/quazip.cpp
+++ b/quazip/quazip.cpp
@@ -28,6 +28,8 @@ quazip/(un)zip.h files for details, basically it's zlib license.
 
 #include "quazip.h"
 
+#include "quazip_textcodec.h"
+
 #define QUAZIP_OS_UNIX 3u
 
 /// All the internal stuff for the QuaZip class.

--- a/quazip/quazip.h
+++ b/quazip/quazip.h
@@ -27,7 +27,7 @@ quazip/(un)zip.h files for details, basically it's zlib license.
 
 #include <QtCore/QString>
 #include <QtCore/QStringList>
-#include "quazip_qt_compat.h"
+
 
 #include "zip.h"
 #include "unzip.h"

--- a/quazip/quazip.h
+++ b/quazip/quazip.h
@@ -226,10 +226,10 @@ class QUAZIP_EXPORT QuaZip {
      * example, file names with cyrillic letters will be in \c IBM866
      * encoding.
      **/
-    void setFileNameCodec(QTextCodec *fileNameCodec);
+    void setFileNameCodec(QuazipTextCodec *fileNameCodec);
     /// Sets the codec used to encode/decode file names inside archive.
     /** \overload
-     * Equivalent to calling setFileNameCodec(QTextCodec::codecForName(codecName));
+     * Equivalent to calling setFileNameCodec(QuazipTextCodec::codecForName(codecName));
      **/
     void setFileNameCodec(const char *fileNameCodecName);
     /// Sets the OS code (highest 8 bits of the “version made by” field) for new files.
@@ -241,18 +241,18 @@ class QUAZIP_EXPORT QuaZip {
     /// Returns the OS code for new files.
     uint getOsCode() const;
     /// Returns the codec used to encode/decode comments inside archive.
-    QTextCodec* getFileNameCodec() const;
+    QuazipTextCodec* getFileNameCodec() const;
     /// Sets the codec used to encode/decode comments inside archive.
     /** This codec defaults to locale codec, which is probably ok.
      **/
-    void setCommentCodec(QTextCodec *commentCodec);
+    void setCommentCodec(QuazipTextCodec *commentCodec);
     /// Sets the codec used to encode/decode comments inside archive.
     /** \overload
-     * Equivalent to calling setCommentCodec(QTextCodec::codecForName(codecName));
+     * Equivalent to calling setCommentCodec(QuazipTextCodec::codecForName(codecName));
      **/
     void setCommentCodec(const char *commentCodecName);
     /// Returns the codec used to encode/decode comments inside archive.
-    QTextCodec* getCommentCodec() const;
+    QuazipTextCodec* getCommentCodec() const;
     /// Returns the name of the ZIP file.
     /** Returns null string if no ZIP file name has been set, for
      * example when the QuaZip instance is set up to use a QIODevice
@@ -570,7 +570,7 @@ class QUAZIP_EXPORT QuaZip {
      * won't affect the QuaZip instances already created at that moment.
      *
      * The codec specified here can be overriden by calling setFileNameCodec().
-     * If neither function is called, QTextCodec::codecForLocale() will be used
+     * If neither function is called, QuazipTextCodec::codecForLocale() will be used
      * to decode or encode file names. Use this function with caution if
      * the application uses other libraries that depend on QuaZip. Those
      * libraries can either call this function by themselves, thus overriding
@@ -594,11 +594,11 @@ class QUAZIP_EXPORT QuaZip {
      *
      * @param codec The codec to use by default. If null, resets to default.
      */
-    static void setDefaultFileNameCodec(QTextCodec *codec);
+    static void setDefaultFileNameCodec(QuazipTextCodec *codec);
     /**
      * @overload
      * Equivalent to calling
-     * setDefaultFileNameCodec(QTextCodec::codecForName(codecName)).
+     * setDefaultFileNameCodec(QuazipTextCodec::codecForName(codecName)).
      */
     static void setDefaultFileNameCodec(const char *codecName);
     /// Sets default OS code.

--- a/quazip/quazip_qt_compat.h
+++ b/quazip/quazip_qt_compat.h
@@ -12,14 +12,6 @@
 #include <QtCore/Qt>
 #include <QtCore/QtGlobal>
 
-// Legacy encodings are still everywhere, but the Qt team decided we
-// don't need them anymore and moved them out of Core in Qt 6.
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-//#  include <QtCore5Compat/QTextCodec>
-#else
-#  include <QtCore/QTextCodec>
-#endif
-
 #include "quazip_textcodec.h"
 
 // QSaveFile terribly breaks the is-a idiom (Liskov substitution principle):

--- a/quazip/quazip_qt_compat.h
+++ b/quazip/quazip_qt_compat.h
@@ -15,10 +15,12 @@
 // Legacy encodings are still everywhere, but the Qt team decided we
 // don't need them anymore and moved them out of Core in Qt 6.
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-#  include <QtCore5Compat/QTextCodec>
+//#  include <QtCore5Compat/QTextCodec>
 #else
 #  include <QtCore/QTextCodec>
 #endif
+
+#include "quazip_textcodec.h"
 
 // QSaveFile terribly breaks the is-a idiom (Liskov substitution principle):
 // QSaveFile is-a QIODevice, but it makes close() private and aborts

--- a/quazip/quazip_qt_compat.h
+++ b/quazip/quazip_qt_compat.h
@@ -12,7 +12,7 @@
 #include <QtCore/Qt>
 #include <QtCore/QtGlobal>
 
-#include "quazip_textcodec.h"
+class QuazipTextCodec;
 
 // QSaveFile terribly breaks the is-a idiom (Liskov substitution principle):
 // QSaveFile is-a QIODevice, but it makes close() private and aborts

--- a/quazip/quazip_textcodec.cpp
+++ b/quazip/quazip_textcodec.cpp
@@ -81,12 +81,11 @@ QuazipTextCodec *QuazipTextCodec::codecForName(const QByteArray &name)
 
 QuazipTextCodec *QuazipTextCodec::codecForLocale()
 {
-#ifndef QUAZIP_CAN_USE_QTEXTCODEC
+#ifdef QUAZIP_CAN_USE_QTEXTCODEC
+    return (QuazipTextCodec*) QTextCodec::codecForLocale();
+#else
     QuazipTextCodec::setup();
     return QuazipTextCodec::codecForName("System");
-#else
-
-    return (QuazipTextCodec*) QTextCodec::codecForLocale();
 #endif
 }
 

--- a/quazip/quazip_textcodec.cpp
+++ b/quazip/quazip_textcodec.cpp
@@ -20,6 +20,7 @@ public:
             QList<QuazipTextCodec*>list_quazip_codecs = static_hash_quazip_codecs->values();
             qDeleteAll(list_quazip_codecs.begin(),list_quazip_codecs.end());
             static_hash_quazip_codecs->clear();
+            delete static_hash_quazip_codecs;
             static_hash_quazip_codecs = nullptr;
         }
     }

--- a/quazip/quazip_textcodec.cpp
+++ b/quazip/quazip_textcodec.cpp
@@ -3,8 +3,8 @@
 #include <QDebug>
 
 
-#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
 
+#ifndef QUAZIP_CAN_USE_QTEXTCODEC
 static QHash<QStringConverter::Encoding,QuazipTextCodec*> *static_hash_quazip_codecs  = nullptr;
 
 class QuazipTextTextCodecCleanup
@@ -35,7 +35,7 @@ QuazipTextCodec::QuazipTextCodec()
 {
 }
 
-#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+#ifndef QUAZIP_CAN_USE_QTEXTCODEC
 
     void QuazipTextCodec::setup()
     {
@@ -50,7 +50,7 @@ QuazipTextCodec::QuazipTextCodec()
 
 QuazipTextCodec *QuazipTextCodec::codecForName(const QByteArray &name)
 {
-    #if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+    #ifndef QUAZIP_CAN_USE_QTEXTCODEC
         QuazipTextCodec::setup();
         QStringConverter::Encoding  encoding = QStringConverter::Utf8;
 
@@ -81,7 +81,7 @@ QuazipTextCodec *QuazipTextCodec::codecForName(const QByteArray &name)
 
 QuazipTextCodec *QuazipTextCodec::codecForLocale()
 {
-#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+#ifndef QUAZIP_CAN_USE_QTEXTCODEC
     QuazipTextCodec::setup();
     return QuazipTextCodec::codecForName("System");
 #else
@@ -92,25 +92,21 @@ QuazipTextCodec *QuazipTextCodec::codecForLocale()
 
 QByteArray QuazipTextCodec::fromUnicode(const QString &str) const
 {
-#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+#ifdef QUAZIP_CAN_USE_QTEXTCODEC
+     return QTextCodec::fromUnicode(str);
+#else
     auto from = QStringEncoder(mEncoding);
     return from(str);
-#else
-
-    return QTextCodec::fromUnicode(str);
-
 #endif
 }
 
 
 QString QuazipTextCodec::toUnicode(const QByteArray &a) const
 {
-#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+#ifdef QUAZIP_CAN_USE_QTEXTCODEC
+       return QTextCodec::toUnicode(a);
+#else
     auto to = QStringDecoder(mEncoding);
     return to(a);
-#else
-
-        return QTextCodec::toUnicode(a);
-
 #endif
 }

--- a/quazip/quazip_textcodec.cpp
+++ b/quazip/quazip_textcodec.cpp
@@ -5,73 +5,50 @@
 
 #if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
 
-static QList<QuazipTextCodec*> *static_list_quazip_codecs  = nullptr;
-
 static QHash<QStringConverter::Encoding,QuazipTextCodec*> *static_hash_quazip_codecs  = nullptr;
-
-
-
-
 
 class QuazipTextTextCodecCleanup
 {
-
 public:
     explicit QuazipTextTextCodecCleanup()
     {
     }
-
     ~QuazipTextTextCodecCleanup()
     {
-        if (static_list_quazip_codecs)
+        if (static_hash_quazip_codecs)
         {
-
-            //qWarning()<<"~QuazipTextTextCodecCleanup()";
-            qDeleteAll(static_list_quazip_codecs->begin(),static_list_quazip_codecs->end());
-            static_list_quazip_codecs->clear();
-            delete static_list_quazip_codecs;
-            static_list_quazip_codecs = nullptr;
+            QList<QuazipTextCodec*>list_quazip_codecs = static_hash_quazip_codecs->values();
+            qDeleteAll(list_quazip_codecs.begin(),list_quazip_codecs.end());
+            static_hash_quazip_codecs->clear();
+            static_hash_quazip_codecs = nullptr;
         }
     }
 };
 
-//////
 Q_GLOBAL_STATIC(QuazipTextTextCodecCleanup, createQuazipTextTextCodecCleanup)
 
 #endif
 
+
 QuazipTextCodec::QuazipTextCodec()
 {
-#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
-
-    QuazipTextCodec::setup();
-    #endif
 }
 
 #if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
-void QuazipTextCodec::setup()
-{
-    if (static_list_quazip_codecs) return;
-      (void)createQuazipTextTextCodecCleanup();
 
-   // qWarning()<<"QuazipTextCodec::setup()";
+    void QuazipTextCodec::setup()
+    {
+        if (static_hash_quazip_codecs) return;
+          (void)createQuazipTextTextCodecCleanup();
 
+        static_hash_quazip_codecs = new QHash<QStringConverter::Encoding,QuazipTextCodec*>;
+    }
 
-    static_list_quazip_codecs = new QList<QuazipTextCodec*>;
-
-
-    static_hash_quazip_codecs = new QHash<QStringConverter::Encoding,QuazipTextCodec*>;
-
-}
-
-    #endif
+#endif
 
 
 QuazipTextCodec *QuazipTextCodec::codecForName(const QByteArray &name)
 {
-
-
-    ///
     #if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
         QuazipTextCodec::setup();
         QStringConverter::Encoding  encoding = QStringConverter::Utf8;
@@ -90,18 +67,15 @@ QuazipTextCodec *QuazipTextCodec::codecForName(const QByteArray &name)
         /////
         codec->mEncoding = encoding;
         static_hash_quazip_codecs->insert(encoding,codec);
-
-        static_list_quazip_codecs->append(codec);
         return codec;
 
     #else
 
     return (QuazipTextCodec*) QTextCodec::codecForName(name);
+
     #endif
 
 }
-
-
 
 
 QuazipTextCodec *QuazipTextCodec::codecForLocale()
@@ -122,10 +96,9 @@ QByteArray QuazipTextCodec::fromUnicode(const QString &str) const
     return from(str);
 #else
 
-        return QTextCodec::fromUnicode(str);
+    return QTextCodec::fromUnicode(str);
 
 #endif
-
 }
 
 

--- a/quazip/quazip_textcodec.cpp
+++ b/quazip/quazip_textcodec.cpp
@@ -1,0 +1,163 @@
+#include "quazip_textcodec.h"
+#include <QCoreApplication>
+#include <QDebug>
+
+static QList<QuazipTextCodec*> *static_list_quazip_codecs  = nullptr;
+
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+
+
+static QHash<QStringConverter::Encoding,QuazipTextCodec*> *static_hash_quazip_codecs  = nullptr;
+#else
+static QHash<QTextCodec*,QuazipTextCodec*> *static_hash_quazip_codecs  = nullptr;
+
+#endif
+
+
+
+class QuazipTextTextCodecCleanup
+{
+
+public:
+    explicit QuazipTextTextCodecCleanup()
+    {
+    }
+
+    ~QuazipTextTextCodecCleanup()
+    {
+        if (static_list_quazip_codecs)
+        {
+
+            //qWarning()<<"~QuazipTextTextCodecCleanup()";
+            qDeleteAll(static_list_quazip_codecs->begin(),static_list_quazip_codecs->end());
+            static_list_quazip_codecs->clear();
+            delete static_list_quazip_codecs;
+            static_list_quazip_codecs = nullptr;
+        }
+    }
+};
+
+//////
+Q_GLOBAL_STATIC(QuazipTextTextCodecCleanup, createQuazipTextTextCodecCleanup)
+
+
+
+QuazipTextCodec::QuazipTextCodec()
+{
+    QuazipTextCodec::setup();
+}
+
+
+void QuazipTextCodec::setup()
+{
+    if (static_list_quazip_codecs) return;
+      (void)createQuazipTextTextCodecCleanup();
+
+   // qWarning()<<"QuazipTextCodec::setup()";
+
+
+    static_list_quazip_codecs = new QList<QuazipTextCodec*>;
+
+    #if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+    static_hash_quazip_codecs = new QHash<QStringConverter::Encoding,QuazipTextCodec*>;
+
+
+    #else
+
+    static_hash_quazip_codecs = new QHash<QTextCodec*,QuazipTextCodec*>;
+
+    #endif
+}
+
+
+
+
+QuazipTextCodec *QuazipTextCodec::codecForName(const QByteArray &name)
+{
+    QuazipTextCodec::setup();
+
+    ///
+    #if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+        QStringConverter::Encoding  encoding = QStringConverter::Utf8;
+
+        std::optional<QStringConverter::Encoding> opt_encoding = QStringConverter::encodingForName(name);
+        if (opt_encoding != std::nullopt)
+        {
+            encoding = opt_encoding.value();
+        }
+        if (static_hash_quazip_codecs->contains(encoding))
+        {
+            return static_hash_quazip_codecs->value(encoding);
+        }
+
+        QuazipTextCodec *codec = new QuazipTextCodec();
+        /////
+        codec->mEncoding = encoding;
+        static_hash_quazip_codecs->insert(encoding,codec);
+
+        static_list_quazip_codecs->append(codec);
+        return codec;
+
+    #else
+
+        QTextCodec *qt_text_codec = QTextCodec::codecForName(name);
+
+        if (qt_text_codec==nullptr)
+        {
+            qt_text_codec = QTextCodec::codecForLocale();
+        }
+
+        if (static_hash_quazip_codecs->contains(qt_text_codec))
+        {
+            return static_hash_quazip_codecs->value(qt_text_codec);
+        }
+        QuazipTextCodec *codec = new QuazipTextCodec();
+        codec->mTextCodec = qt_text_codec;
+        static_hash_quazip_codecs->insert(qt_text_codec,codec);
+
+        static_list_quazip_codecs->append(codec);
+        return codec;
+
+
+    #endif
+
+}
+
+
+
+
+QuazipTextCodec *QuazipTextCodec::codecForLocale()
+{
+    QuazipTextCodec::setup();
+    return QuazipTextCodec::codecForName("System");
+}
+
+QByteArray QuazipTextCodec::fromUnicode(const QString &str) const
+{
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+    auto from = QStringEncoder(mEncoding);
+    return from(str);
+#else
+    if (mTextCodec)
+    {
+        return mTextCodec->fromUnicode(str);
+    }
+#endif
+    return QByteArray();
+}
+
+
+QString QuazipTextCodec::toUnicode(const QByteArray &a) const
+{
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+    auto to = QStringDecoder(mEncoding);
+    return to(a);
+#else
+    if (mTextCodec)
+    {
+        return mTextCodec->toUnicode(a);
+    }
+#endif
+    return QString();
+}
+

--- a/quazip/quazip_textcodec.h
+++ b/quazip/quazip_textcodec.h
@@ -3,8 +3,6 @@
 
 #include <QByteArray>
 
-
-
 #if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
 #include <QStringConverter>
 #else
@@ -30,12 +28,12 @@ public:
 protected:
 
 #if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
-        static void setup();
+    static void setup();
     QStringConverter::Encoding  mEncoding;
 #endif
+};
 
-
-
+#endif // QUAZIPTEXTCODEC_H
 
 
 };

--- a/quazip/quazip_textcodec.h
+++ b/quazip/quazip_textcodec.h
@@ -4,17 +4,18 @@
 #include <QByteArray>
 #include "quazip_global.h"
 
-#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
-#include <QStringConverter>
+#ifdef QUAZIP_CAN_USE_QTEXTCODEC
+   #include <QTextCodec>
+
 #else
-    #include <QTextCodec>
+    #include <QStringConverter>
 #endif
 
 
-#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
-class QUAZIP_EXPORT QuazipTextCodec
-#else
+#ifdef QUAZIP_CAN_USE_QTEXTCODEC
 class QUAZIP_EXPORT QuazipTextCodec: public QTextCodec
+#else
+class QUAZIP_EXPORT QuazipTextCodec
 #endif
 {
     
@@ -28,7 +29,7 @@ public:
     static QuazipTextCodec *codecForLocale();
 protected:
 
-#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+#ifndef QUAZIP_CAN_USE_QTEXTCODEC
     static void setup();
     QStringConverter::Encoding  mEncoding;
 #endif

--- a/quazip/quazip_textcodec.h
+++ b/quazip/quazip_textcodec.h
@@ -12,8 +12,11 @@
 #endif
 
 
-
-class QuazipTextCodec 
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+class QuazipTextCodec
+#else
+class QuazipTextCodec : public QTextCodec
+#endif
 {
     
 public:
@@ -26,12 +29,9 @@ public:
     static QuazipTextCodec *codecForLocale();
 protected:
 
-    static void setup();
-
 #if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+        static void setup();
     QStringConverter::Encoding  mEncoding;
-#else
-    QTextCodec *mTextCodec = nullptr;
 #endif
 
 
@@ -41,3 +41,4 @@ protected:
 };
 
 #endif // QUAZIPTEXTCODEC_H
+

--- a/quazip/quazip_textcodec.h
+++ b/quazip/quazip_textcodec.h
@@ -1,0 +1,43 @@
+#ifndef QUAZIPTEXTCODEC_H
+#define QUAZIPTEXTCODEC_H
+
+#include <QByteArray>
+
+
+
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+#include <QStringConverter>
+#else
+    #include <QTextCodec>
+#endif
+
+
+
+class QuazipTextCodec 
+{
+    
+public:
+    explicit QuazipTextCodec();
+
+    QByteArray fromUnicode(const QString &str) const;
+    QString toUnicode(const QByteArray &a) const;
+
+    static QuazipTextCodec *codecForName(const QByteArray &name);
+    static QuazipTextCodec *codecForLocale();
+protected:
+
+    static void setup();
+
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+    QStringConverter::Encoding  mEncoding;
+#else
+    QTextCodec *mTextCodec = nullptr;
+#endif
+
+
+
+
+
+};
+
+#endif // QUAZIPTEXTCODEC_H

--- a/quazip/quazip_textcodec.h
+++ b/quazip/quazip_textcodec.h
@@ -2,6 +2,7 @@
 #define QUAZIPTEXTCODEC_H
 
 #include <QByteArray>
+#include "quazip_global.h"
 
 #if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
 #include <QStringConverter>
@@ -11,9 +12,9 @@
 
 
 #if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
-class QuazipTextCodec
+class QUAZIP_EXPORT QuazipTextCodec
 #else
-class QuazipTextCodec : public QTextCodec
+class QUAZIP_EXPORT QuazipTextCodec: public QTextCodec
 #endif
 {
     
@@ -34,9 +35,3 @@ protected:
 };
 
 #endif // QUAZIPTEXTCODEC_H
-
-
-};
-
-#endif // QUAZIPTEXTCODEC_H
-

--- a/quazip/quazipfile.cpp
+++ b/quazip/quazipfile.cpp
@@ -26,6 +26,9 @@ quazip/(un)zip.h files for details, basically it's zlib license.
 
 #include "quazipfileinfo.h"
 
+
+#include "quazip_textcodec.h"
+
 using namespace std;
 
 #define QUAZIP_VERSION_MADE_BY 0x1Eu

--- a/qztest/qztest.cpp
+++ b/qztest/qztest.cpp
@@ -85,7 +85,7 @@ bool createTestFiles(const QStringList &fileNames, int size, const QString &dir)
 
 bool createTestArchive(QuaZip &zip, const QString &zipName,
                        const QStringList &fileNames,
-                       QTextCodec *codec,
+                       QuazipTextCodec *codec,
                        const QString &dir)
 {
     if (codec != NULL) {
@@ -158,7 +158,7 @@ bool createTestArchive(const QString &zipName,
 
 bool createTestArchive(QIODevice *ioDevice,
                               const QStringList &fileNames,
-                              QTextCodec *codec,
+                              QuazipTextCodec *codec,
                               const QString &dir)
 {
     QuaZip zip(ioDevice);
@@ -167,7 +167,7 @@ bool createTestArchive(QIODevice *ioDevice,
 
 bool createTestArchive(const QString &zipName,
                               const QStringList &fileNames,
-                              QTextCodec *codec,
+                              QuazipTextCodec *codec,
                               const QString &dir) {
     QuaZip zip(zipName);
     return createTestArchive(zip, zipName, fileNames, codec, dir);

--- a/qztest/qztest.h
+++ b/qztest/qztest.h
@@ -41,11 +41,11 @@ extern bool createTestArchive(const QString &zipName,
                               const QString &dir = "tmp");
 extern bool createTestArchive(const QString &zipName,
                               const QStringList &fileNames,
-                              QTextCodec *codec,
+                              QuazipTextCodec *codec,
                               const QString &dir = "tmp");
 extern bool createTestArchive(QIODevice *ioDevice,
                               const QStringList &fileNames,
-                              QTextCodec *codec,
+                              QuazipTextCodec *codec,
                               const QString &dir = "tmp");
 
 #endif // QUAZIP_TEST_QZTEST_H

--- a/qztest/testjlcompress.cpp
+++ b/qztest/testjlcompress.cpp
@@ -209,7 +209,7 @@ void TestJlCompress::extractFile()
     srcPerm ^= QFile::WriteOther;
     QVERIFY(srcFile.setPermissions(srcPerm));
     if (!createTestArchive(zipName, fileNames,
-                           QTextCodec::codecForName(encoding))) {
+                           QuazipTextCodec::codecForName(encoding))) {
         QFAIL("Can't create test archive");
     }
     QuaZip::setDefaultFileNameCodec(encoding);
@@ -373,9 +373,9 @@ void TestJlCompress::extractDir()
             QFAIL("Couldn't change to /");
         }
     }
-    QTextCodec *fileNameCodec = NULL;
+    QuazipTextCodec *fileNameCodec = NULL;
     if (!fileNameCodecName.isEmpty())
-        fileNameCodec = QTextCodec::codecForName(fileNameCodecName);
+        fileNameCodec = QuazipTextCodec::codecForName(fileNameCodecName);
     QDir curDir;
     if (!extDir.isEmpty() && !curDir.mkpath(extDir)) {
         QFAIL("Couldn't mkpath extDir");

--- a/qztest/testquazip.cpp
+++ b/qztest/testquazip.cpp
@@ -188,7 +188,7 @@ void TestQuaZip::setFileNameCodec()
         QFAIL("Can't create test file");
     }
     if (!createTestArchive(zipName, fileNames,
-                           QTextCodec::codecForName(encoding))) {
+                           QuazipTextCodec::codecForName(encoding))) {
         QFAIL("Can't create test archive");
     }
     QuaZip testZip(zipName);
@@ -369,7 +369,7 @@ void TestQuaZip::setCommentCodec()
     zipFile.close();
     zip.close();
     QVERIFY(zip.open(QuaZip::mdUnzip));
-    zip.setCommentCodec(QTextCodec::codecForName("KOI8-R"));
+    zip.setCommentCodec(QuazipTextCodec::codecForName("KOI8-R"));
     QCOMPARE(zip.getComment(), QString::fromUtf8("бНОПНЯ"));
     zip.close();
     QDir().remove(zip.getZipName());


### PR DESCRIPTION
Remove dependency on QTextCodec for qt6 with QStringConvert and no longer need to include the QT5CoreCompat module
Pass qztest on qt5 and qt6
One warning for qt6 for the Russian language :
   Actual   (zip.getComment())           : "\u0412\u043E\u043F\u0440\u043E\u0441"
   Expected (QString::fromUtf8("бНОПНЯ")): "\u0431\u041D\u041E\u041F\u041D\u042F"