### PR TITLE
Remove dependency on QTextCodec for qt6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ cmake-*
 CMakeUserPresets.json
 vcpkg_installed/
 Testing/
+CMakeFiles/
+CMakeCache.txt

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,13 +78,13 @@ set(QUAZIP_DIR_NAME QuaZip-Qt${QUAZIP_QT_MAJOR_VERSION}-${QUAZIP_LIB_VERSION})
 set(QUAZIP_PACKAGE_NAME QuaZip-Qt${QUAZIP_QT_MAJOR_VERSION})
 
 if(QUAZIP_QT_MAJOR_VERSION EQUAL 6)
-    find_package(Qt6 REQUIRED COMPONENTS Core Core5Compat
+    find_package(Qt6 REQUIRED COMPONENTS Core 
             OPTIONAL_COMPONENTS Network Test)
     message(STATUS "Found Qt version ${Qt6_VERSION} at ${Qt6_DIR}")
     set(QUAZIP_QT_ZLIB_COMPONENT BundledZLIB)
     set(QUAZIP_QT_ZLIB_HEADER_COMPONENT ZlibPrivate)
-    set(QUAZIP_LIB_LIBRARIES Qt6::Core Qt6::Core5Compat)
-    set(QUAZIP_TEST_QT_LIBRARIES Qt6::Core Qt6::Core5Compat Qt6::Network Qt6::Test)
+    set(QUAZIP_LIB_LIBRARIES Qt6::Core )
+    set(QUAZIP_TEST_QT_LIBRARIES Qt6::Core Qt6::Network Qt6::Test)
     set(QUAZIP_PKGCONFIG_REQUIRES "zlib, Qt6Core")
 elseif(QUAZIP_QT_MAJOR_VERSION EQUAL 5)
     find_package(Qt5 REQUIRED COMPONENTS Core
@@ -224,6 +224,27 @@ if(QUAZIP_BZIP2)
         add_compile_definitions(HAVE_BZIP2)
     endif()
 endif()
+
+#issue Qt5/Qt6 / Core5Compat and QTextCodec
+
+
+if(${QT_VERSION} VERSION_GREATER_EQUAL 6.0.0)
+
+    find_package(Qt6 OPTIONAL_COMPONENTS  Core5Compat)
+
+  if(Qt6Core5Compat_FOUND)
+        set(QUAZIP_LIB_LIBRARIES ${QUAZIP_LIB_LIBRARIES} Qt6::Core5Compat)
+        set(QUAZIP_TEST_QT_LIBRARIES ${QUAZIP_TEST_QT_LIBRARIES} Qt6::Core5Compat)
+  
+    add_compile_definitions( QUAZIP_CAN_USE_QTEXTCODEC)
+     message("-- Quazip use QTextCodec")
+    
+  endif()
+else()
+    add_compile_definitions( QUAZIP_CAN_USE_QTEXTCODEC)
+     message("-- Quazip use QTextCodec")
+endif()
+
 
 add_subdirectory(quazip)
 

--- a/quazip/CMakeLists.txt
+++ b/quazip/CMakeLists.txt
@@ -16,6 +16,9 @@ set(QUAZIP_HEADERS
         quazip.h
         quazip_global.h
         quazip_qt_compat.h
+
+        quazip_textcodec.h
+
         quazipdir.h
         quazipfile.h
         quazipfileinfo.h
@@ -36,6 +39,9 @@ set(QUAZIP_SOURCES
         quagzipfile.cpp
         quaziodevice.cpp
         quazip.cpp
+
+        quazip_textcodec.cpp
+
         quazipdir.cpp
         quazipfile.cpp
         quazipfileinfo.cpp

--- a/quazip/JlCompress.cpp
+++ b/quazip/JlCompress.cpp
@@ -350,8 +350,8 @@ QStringList JlCompress::extractFiles(QuaZip &zip, const QStringList &files, cons
     return extracted;
 }
 
-QStringList JlCompress::extractDir(QString fileCompressed, QTextCodec* fileNameCodec, QString dir) {
-    // Open zip
+QStringList JlCompress::extractDir(QString fileCompressed, QuazipTextCodec* fileNameCodec, QString dir) {
+    // Apro lo zip
     QuaZip zip(fileCompressed);
     if (fileNameCodec)
         zip.setFileNameCodec(fileNameCodec);
@@ -434,7 +434,7 @@ QStringList JlCompress::getFileList(QuaZip *zip)
     return lst;
 }
 
-QStringList JlCompress::extractDir(QIODevice* ioDevice, QTextCodec* fileNameCodec, QString dir)
+QStringList JlCompress::extractDir(QIODevice* ioDevice, QuazipTextCodec* fileNameCodec, QString dir)
 {
     QuaZip zip(ioDevice);
     if (fileNameCodec)

--- a/quazip/JlCompress.h
+++ b/quazip/JlCompress.h
@@ -160,7 +160,7 @@ public:
       left empty.
       \return The list of the full paths of the files extracted, empty on failure.
       */
-    static QStringList extractDir(QString fileCompressed, QTextCodec* fileNameCodec, QString dir = QString());
+    static QStringList extractDir(QString fileCompressed, QuazipTextCodec* fileNameCodec, QString dir = QString());
     /// Get the file list.
     /**
       \return The list of the files in the archive, or, more precisely, the
@@ -202,7 +202,7 @@ public:
       left empty.
       \return The list of the full paths of the files extracted, empty on failure.
       */
-    static QStringList extractDir(QIODevice* ioDevice, QTextCodec* fileNameCodec, QString dir = QString());
+    static QStringList extractDir(QIODevice* ioDevice, QuazipTextCodec* fileNameCodec, QString dir = QString());
     /// Get the file list.
     /**
       \return The list of the files in the archive, or, more precisely, the

--- a/quazip/quazip.cpp
+++ b/quazip/quazip.cpp
@@ -28,6 +28,8 @@ quazip/(un)zip.h files for details, basically it's zlib license.
 
 #include "quazip.h"
 
+#include "quazip_textcodec.h"
+
 #define QUAZIP_OS_UNIX 3u
 
 /// All the internal stuff for the QuaZip class.
@@ -45,9 +47,9 @@ class QuaZipPrivate {
     /// The pointer to the corresponding QuaZip instance.
     QuaZip *q;
     /// The codec for file names (used when UTF-8 is not enabled).
-    QTextCodec *fileNameCodec;
+    QuazipTextCodec *fileNameCodec;
     /// The codec for comments (used when UTF-8 is not enabled).
-    QTextCodec *commentCodec;
+    QuazipTextCodec *commentCodec;
     /// The archive file name.
     QString zipName;
     /// The device to access the archive.
@@ -76,10 +78,10 @@ class QuaZipPrivate {
     bool utf8;
     /// The OS code.
     uint osCode;
-    inline QTextCodec *getDefaultFileNameCodec()
+    inline QuazipTextCodec *getDefaultFileNameCodec()
     {
         if (defaultFileNameCodec == nullptr) {
-          return QTextCodec::codecForLocale();
+          return QuazipTextCodec::codecForLocale();
         }
         return defaultFileNameCodec;
     }
@@ -87,7 +89,7 @@ class QuaZipPrivate {
     inline QuaZipPrivate(QuaZip *q):
       q(q),
       fileNameCodec(getDefaultFileNameCodec()),
-      commentCodec(QTextCodec::codecForLocale()),
+      commentCodec(QuazipTextCodec::codecForLocale()),
       ioDevice(nullptr),
       mode(QuaZip::mdNotOpen),
       hasCurrentFile_f(false),
@@ -107,7 +109,7 @@ class QuaZipPrivate {
     inline QuaZipPrivate(QuaZip *q, const QString &zipName):
       q(q),
       fileNameCodec(getDefaultFileNameCodec()),
-      commentCodec(QTextCodec::codecForLocale()),
+      commentCodec(QuazipTextCodec::codecForLocale()),
       zipName(zipName),
       ioDevice(nullptr),
       mode(QuaZip::mdNotOpen),
@@ -128,7 +130,7 @@ class QuaZipPrivate {
     inline QuaZipPrivate(QuaZip *q, QIODevice *ioDevice):
       q(q),
       fileNameCodec(getDefaultFileNameCodec()),
-      commentCodec(QTextCodec::codecForLocale()),
+      commentCodec(QuazipTextCodec::codecForLocale()),
       ioDevice(ioDevice),
       mode(QuaZip::mdNotOpen),
       hasCurrentFile_f(false),
@@ -155,11 +157,11 @@ class QuaZipPrivate {
       QHash<QString, unz64_file_pos> directoryCaseSensitive;
       QHash<QString, unz64_file_pos> directoryCaseInsensitive;
       unz64_file_pos lastMappedDirectoryEntry;
-      static QTextCodec *defaultFileNameCodec;
+      static QuazipTextCodec *defaultFileNameCodec;
       static uint defaultOsCode;
 };
 
-QTextCodec *QuaZipPrivate::defaultFileNameCodec = nullptr;
+QuazipTextCodec *QuaZipPrivate::defaultFileNameCodec = nullptr;
 uint QuaZipPrivate::defaultOsCode = QUAZIP_OS_UNIX;
 
 void QuaZipPrivate::clearDirectoryMap()
@@ -588,14 +590,14 @@ QString QuaZip::getCurrentFileName()const
   return result;
 }
 
-void QuaZip::setFileNameCodec(QTextCodec *fileNameCodec)
+void QuaZip::setFileNameCodec(QuazipTextCodec *fileNameCodec)
 {
   p->fileNameCodec=fileNameCodec;
 }
 
 void QuaZip::setFileNameCodec(const char *fileNameCodecName)
 {
-    p->fileNameCodec=QTextCodec::codecForName(fileNameCodecName);
+    p->fileNameCodec=QuazipTextCodec::codecForName(fileNameCodecName);
 }
 
 void QuaZip::setOsCode(uint osCode)
@@ -608,22 +610,22 @@ uint QuaZip::getOsCode() const
     return p->osCode;
 }
 
-QTextCodec *QuaZip::getFileNameCodec()const
+QuazipTextCodec *QuaZip::getFileNameCodec()const
 {
   return p->fileNameCodec;
 }
 
-void QuaZip::setCommentCodec(QTextCodec *commentCodec)
+void QuaZip::setCommentCodec(QuazipTextCodec *commentCodec)
 {
   p->commentCodec=commentCodec;
 }
 
 void QuaZip::setCommentCodec(const char *commentCodecName)
 {
-  p->commentCodec=QTextCodec::codecForName(commentCodecName);
+  p->commentCodec=QuazipTextCodec::codecForName(commentCodecName);
 }
 
-QTextCodec *QuaZip::getCommentCodec()const
+QuazipTextCodec *QuaZip::getCommentCodec()const
 {
   return p->commentCodec;
 }
@@ -783,14 +785,14 @@ Qt::CaseSensitivity QuaZip::convertCaseSensitivity(QuaZip::CaseSensitivity cs)
   }
 }
 
-void QuaZip::setDefaultFileNameCodec(QTextCodec *codec)
+void QuaZip::setDefaultFileNameCodec(QuazipTextCodec *codec)
 {
     QuaZipPrivate::defaultFileNameCodec = codec;
 }
 
 void QuaZip::setDefaultFileNameCodec(const char *codecName)
 {
-    setDefaultFileNameCodec(QTextCodec::codecForName(codecName));
+    setDefaultFileNameCodec(QuazipTextCodec::codecForName(codecName));
 }
 
 void QuaZip::setDefaultOsCode(uint osCode)

--- a/quazip/quazip.h
+++ b/quazip/quazip.h
@@ -27,7 +27,7 @@ quazip/(un)zip.h files for details, basically it's zlib license.
 
 #include <QtCore/QString>
 #include <QtCore/QStringList>
-#include "quazip_qt_compat.h"
+
 
 #include "zip.h"
 #include "unzip.h"
@@ -226,10 +226,10 @@ class QUAZIP_EXPORT QuaZip {
      * example, file names with cyrillic letters will be in \c IBM866
      * encoding.
      **/
-    void setFileNameCodec(QTextCodec *fileNameCodec);
+    void setFileNameCodec(QuazipTextCodec *fileNameCodec);
     /// Sets the codec used to encode/decode file names inside archive.
     /** \overload
-     * Equivalent to calling setFileNameCodec(QTextCodec::codecForName(codecName));
+     * Equivalent to calling setFileNameCodec(QuazipTextCodec::codecForName(codecName));
      **/
     void setFileNameCodec(const char *fileNameCodecName);
     /// Sets the OS code (highest 8 bits of the “version made by” field) for new files.
@@ -241,18 +241,18 @@ class QUAZIP_EXPORT QuaZip {
     /// Returns the OS code for new files.
     uint getOsCode() const;
     /// Returns the codec used to encode/decode comments inside archive.
-    QTextCodec* getFileNameCodec() const;
+    QuazipTextCodec* getFileNameCodec() const;
     /// Sets the codec used to encode/decode comments inside archive.
     /** This codec defaults to locale codec, which is probably ok.
      **/
-    void setCommentCodec(QTextCodec *commentCodec);
+    void setCommentCodec(QuazipTextCodec *commentCodec);
     /// Sets the codec used to encode/decode comments inside archive.
     /** \overload
-     * Equivalent to calling setCommentCodec(QTextCodec::codecForName(codecName));
+     * Equivalent to calling setCommentCodec(QuazipTextCodec::codecForName(codecName));
      **/
     void setCommentCodec(const char *commentCodecName);
     /// Returns the codec used to encode/decode comments inside archive.
-    QTextCodec* getCommentCodec() const;
+    QuazipTextCodec* getCommentCodec() const;
     /// Returns the name of the ZIP file.
     /** Returns null string if no ZIP file name has been set, for
      * example when the QuaZip instance is set up to use a QIODevice
@@ -570,7 +570,7 @@ class QUAZIP_EXPORT QuaZip {
      * won't affect the QuaZip instances already created at that moment.
      *
      * The codec specified here can be overriden by calling setFileNameCodec().
-     * If neither function is called, QTextCodec::codecForLocale() will be used
+     * If neither function is called, QuazipTextCodec::codecForLocale() will be used
      * to decode or encode file names. Use this function with caution if
      * the application uses other libraries that depend on QuaZip. Those
      * libraries can either call this function by themselves, thus overriding
@@ -594,11 +594,11 @@ class QUAZIP_EXPORT QuaZip {
      *
      * @param codec The codec to use by default. If null, resets to default.
      */
-    static void setDefaultFileNameCodec(QTextCodec *codec);
+    static void setDefaultFileNameCodec(QuazipTextCodec *codec);
     /**
      * @overload
      * Equivalent to calling
-     * setDefaultFileNameCodec(QTextCodec::codecForName(codecName)).
+     * setDefaultFileNameCodec(QuazipTextCodec::codecForName(codecName)).
      */
     static void setDefaultFileNameCodec(const char *codecName);
     /// Sets default OS code.

--- a/quazip/quazip.h
+++ b/quazip/quazip.h
@@ -35,6 +35,8 @@ quazip/(un)zip.h files for details, basically it's zlib license.
 #include "quazip_global.h"
 #include "quazipfileinfo.h"
 
+#include "quazip_textcodec.h"
+
 // just in case it will be defined in the later versions of the ZIP/UNZIP
 #ifndef UNZ_OPENERROR
 // define additional error code

--- a/quazip/quazip_qt_compat.h
+++ b/quazip/quazip_qt_compat.h
@@ -12,13 +12,7 @@
 #include <QtCore/Qt>
 #include <QtCore/QtGlobal>
 
-// Legacy encodings are still everywhere, but the Qt team decided we
-// don't need them anymore and moved them out of Core in Qt 6.
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-#  include <QtCore5Compat/QTextCodec>
-#else
-#  include <QtCore/QTextCodec>
-#endif
+class QuazipTextCodec;
 
 // QSaveFile terribly breaks the is-a idiom (Liskov substitution principle):
 // QSaveFile is-a QIODevice, but it makes close() private and aborts

--- a/quazip/quazip_textcodec.cpp
+++ b/quazip/quazip_textcodec.cpp
@@ -1,0 +1,137 @@
+/*
+Copyright (C) 2024 Gregory EUSTACHE
+
+QuazipTextCodec is a wrapper/abstraction around QTextCodec
+
+
+This file is part of QuaZip.
+
+QuaZip is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2.1 of the License, or
+(at your option) any later version.
+
+QuaZip is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with QuaZip.  If not, see <http://www.gnu.org/licenses/>.
+
+See COPYING file for the full LGPL text.
+
+*/
+
+
+#include "quazip_textcodec.h"
+#include <QCoreApplication>
+#include <QDebug>
+
+
+
+#ifndef QUAZIP_CAN_USE_QTEXTCODEC
+static QHash<QStringConverter::Encoding,QuazipTextCodec*> *static_hash_quazip_codecs  = nullptr;
+
+class QuazipTextTextCodecCleanup
+{
+public:
+    explicit QuazipTextTextCodecCleanup()
+    {
+    }
+    ~QuazipTextTextCodecCleanup()
+    {
+        if (static_hash_quazip_codecs)
+        {
+            QList<QuazipTextCodec*>list_quazip_codecs = static_hash_quazip_codecs->values();
+            qDeleteAll(list_quazip_codecs.begin(),list_quazip_codecs.end());
+            static_hash_quazip_codecs->clear();
+            delete static_hash_quazip_codecs;
+            static_hash_quazip_codecs = nullptr;
+        }
+    }
+};
+
+Q_GLOBAL_STATIC(QuazipTextTextCodecCleanup, createQuazipTextTextCodecCleanup)
+
+#endif
+
+
+QuazipTextCodec::QuazipTextCodec()
+{
+}
+
+#ifndef QUAZIP_CAN_USE_QTEXTCODEC
+
+    void QuazipTextCodec::setup()
+    {
+        if (static_hash_quazip_codecs) return;
+          (void)createQuazipTextTextCodecCleanup();
+
+        static_hash_quazip_codecs = new QHash<QStringConverter::Encoding,QuazipTextCodec*>;
+    }
+
+#endif
+
+
+QuazipTextCodec *QuazipTextCodec::codecForName(const QByteArray &name)
+{
+    #ifndef QUAZIP_CAN_USE_QTEXTCODEC
+        QuazipTextCodec::setup();
+        QStringConverter::Encoding  encoding = QStringConverter::Utf8;
+
+        std::optional<QStringConverter::Encoding> opt_encoding = QStringConverter::encodingForName(name);
+        if (opt_encoding != std::nullopt)
+        {
+            encoding = opt_encoding.value();
+        }
+        if (static_hash_quazip_codecs->contains(encoding))
+        {
+            return static_hash_quazip_codecs->value(encoding);
+        }
+
+        QuazipTextCodec *codec = new QuazipTextCodec();
+        /////
+        codec->mEncoding = encoding;
+        static_hash_quazip_codecs->insert(encoding,codec);
+        return codec;
+
+    #else
+
+    return (QuazipTextCodec*) QTextCodec::codecForName(name);
+
+    #endif
+
+}
+
+
+QuazipTextCodec *QuazipTextCodec::codecForLocale()
+{
+#ifdef QUAZIP_CAN_USE_QTEXTCODEC
+    return (QuazipTextCodec*) QTextCodec::codecForLocale();
+#else
+    QuazipTextCodec::setup();
+    return QuazipTextCodec::codecForName("System");
+#endif
+}
+
+QByteArray QuazipTextCodec::fromUnicode(const QString &str) const
+{
+#ifdef QUAZIP_CAN_USE_QTEXTCODEC
+     return QTextCodec::fromUnicode(str);
+#else
+    auto from = QStringEncoder(mEncoding);
+    return from(str);
+#endif
+}
+
+
+QString QuazipTextCodec::toUnicode(const QByteArray &a) const
+{
+#ifdef QUAZIP_CAN_USE_QTEXTCODEC
+       return QTextCodec::toUnicode(a);
+#else
+    auto to = QStringDecoder(mEncoding);
+    return to(a);
+#endif
+}

--- a/quazip/quazip_textcodec.h
+++ b/quazip/quazip_textcodec.h
@@ -1,0 +1,63 @@
+/*
+Copyright (C) 2024 Gregory EUSTACHE
+
+QuazipTextCodec is a wrapper/abstraction around QTextCodec
+
+
+This file is part of QuaZip.
+
+QuaZip is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2.1 of the License, or
+(at your option) any later version.
+
+QuaZip is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with QuaZip.  If not, see <http://www.gnu.org/licenses/>.
+
+See COPYING file for the full LGPL text.
+
+*/
+
+#ifndef QUAZIPTEXTCODEC_H
+#define QUAZIPTEXTCODEC_H
+
+#include <QByteArray>
+#include "quazip_global.h"
+
+#ifdef QUAZIP_CAN_USE_QTEXTCODEC
+   #include <QTextCodec>
+
+#else
+    #include <QStringConverter>
+#endif
+
+
+#ifdef QUAZIP_CAN_USE_QTEXTCODEC
+class QUAZIP_EXPORT QuazipTextCodec: public QTextCodec
+#else
+class QUAZIP_EXPORT QuazipTextCodec
+#endif
+{
+    
+public:
+    explicit QuazipTextCodec();
+
+    QByteArray fromUnicode(const QString &str) const;
+    QString toUnicode(const QByteArray &a) const;
+
+    static QuazipTextCodec *codecForName(const QByteArray &name);
+    static QuazipTextCodec *codecForLocale();
+protected:
+
+#ifndef QUAZIP_CAN_USE_QTEXTCODEC
+    static void setup();
+    QStringConverter::Encoding  mEncoding;
+#endif
+};
+
+#endif // QUAZIPTEXTCODEC_H

--- a/quazip/quazipfile.cpp
+++ b/quazip/quazipfile.cpp
@@ -26,6 +26,9 @@ quazip/(un)zip.h files for details, basically it's zlib license.
 
 #include "quazipfileinfo.h"
 
+
+#include "quazip_textcodec.h"
+
 using namespace std;
 
 #define QUAZIP_VERSION_MADE_BY 0x1Eu

--- a/qztest/qztest.cpp
+++ b/qztest/qztest.cpp
@@ -85,7 +85,7 @@ bool createTestFiles(const QStringList &fileNames, int size, const QString &dir)
 
 bool createTestArchive(QuaZip &zip, const QString &zipName,
                        const QStringList &fileNames,
-                       QTextCodec *codec,
+                       QuazipTextCodec *codec,
                        const QString &dir)
 {
     if (codec != NULL) {
@@ -158,7 +158,7 @@ bool createTestArchive(const QString &zipName,
 
 bool createTestArchive(QIODevice *ioDevice,
                               const QStringList &fileNames,
-                              QTextCodec *codec,
+                              QuazipTextCodec *codec,
                               const QString &dir)
 {
     QuaZip zip(ioDevice);
@@ -167,7 +167,7 @@ bool createTestArchive(QIODevice *ioDevice,
 
 bool createTestArchive(const QString &zipName,
                               const QStringList &fileNames,
-                              QTextCodec *codec,
+                              QuazipTextCodec *codec,
                               const QString &dir) {
     QuaZip zip(zipName);
     return createTestArchive(zip, zipName, fileNames, codec, dir);

--- a/qztest/qztest.h
+++ b/qztest/qztest.h
@@ -41,11 +41,11 @@ extern bool createTestArchive(const QString &zipName,
                               const QString &dir = "tmp");
 extern bool createTestArchive(const QString &zipName,
                               const QStringList &fileNames,
-                              QTextCodec *codec,
+                              QuazipTextCodec *codec,
                               const QString &dir = "tmp");
 extern bool createTestArchive(QIODevice *ioDevice,
                               const QStringList &fileNames,
-                              QTextCodec *codec,
+                              QuazipTextCodec *codec,
                               const QString &dir = "tmp");
 
 #endif // QUAZIP_TEST_QZTEST_H

--- a/qztest/testjlcompress.cpp
+++ b/qztest/testjlcompress.cpp
@@ -209,7 +209,7 @@ void TestJlCompress::extractFile()
     srcPerm ^= QFile::WriteOther;
     QVERIFY(srcFile.setPermissions(srcPerm));
     if (!createTestArchive(zipName, fileNames,
-                           QTextCodec::codecForName(encoding))) {
+                           QuazipTextCodec::codecForName(encoding))) {
         QFAIL("Can't create test archive");
     }
     QuaZip::setDefaultFileNameCodec(encoding);
@@ -373,9 +373,9 @@ void TestJlCompress::extractDir()
             QFAIL("Couldn't change to /");
         }
     }
-    QTextCodec *fileNameCodec = NULL;
+    QuazipTextCodec *fileNameCodec = NULL;
     if (!fileNameCodecName.isEmpty())
-        fileNameCodec = QTextCodec::codecForName(fileNameCodecName);
+        fileNameCodec = QuazipTextCodec::codecForName(fileNameCodecName);
     QDir curDir;
     if (!extDir.isEmpty() && !curDir.mkpath(extDir)) {
         QFAIL("Couldn't mkpath extDir");

--- a/qztest/testquazip.cpp
+++ b/qztest/testquazip.cpp
@@ -188,7 +188,7 @@ void TestQuaZip::setFileNameCodec()
         QFAIL("Can't create test file");
     }
     if (!createTestArchive(zipName, fileNames,
-                           QTextCodec::codecForName(encoding))) {
+                           QuazipTextCodec::codecForName(encoding))) {
         QFAIL("Can't create test archive");
     }
     QuaZip testZip(zipName);
@@ -369,7 +369,7 @@ void TestQuaZip::setCommentCodec()
     zipFile.close();
     zip.close();
     QVERIFY(zip.open(QuaZip::mdUnzip));
-    zip.setCommentCodec(QTextCodec::codecForName("KOI8-R"));
+    zip.setCommentCodec(QuazipTextCodec::codecForName("KOI8-R"));
     QCOMPARE(zip.getComment(), QString::fromUtf8("бНОПНЯ"));
     zip.close();
     QDir().remove(zip.getZipName());


### PR DESCRIPTION
Remove dependency on QTextCodec for qt6 with QStringConvert
3 cases
Qt5 -> Use QTextCodec
QT6 + Core5Compat  -> Use QTextCodec (more encoding available)
QT6 without Core5Compat  -> Use QStringConvert (less encoding available but probably enought for new projects)