### PR TITLE
JlCompress UTF-8 support, encryption, fluent interface

### DIFF
--- a/.github/workflows/qt-zlib.yml
+++ b/.github/workflows/qt-zlib.yml
@@ -180,6 +180,37 @@ jobs:
         shell: cmd
         run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
 
+      - name: Debug - Check qztest.exe exists
+        shell: bash
+        working-directory: ${{github.workspace}}/build
+        run: |
+          echo "=== Searching for qztest.exe ==="
+          find . -name "qztest.exe" -ls || true
+          echo "=== Contents of qztest directory ==="
+          ls -la qztest/ || true
+          ls -la qztest/Release/ || true
+
+      - name: Debug - Try running qztest.exe directly
+        shell: bash
+        working-directory: ${{github.workspace}}/build
+        continue-on-error: true
+        run: |
+          echo "=== Attempting to run qztest.exe directly ==="
+          if [ -f "qztest/Release/qztest.exe" ]; then
+            echo "Found qztest.exe, attempting to run..."
+            ./qztest/Release/qztest.exe --help || echo "Exit code: $?"
+          else
+            echo "qztest.exe not found in expected location"
+          fi
+
+      - name: Debug - Check environment
+        shell: bash
+        run: |
+          echo "=== PATH ==="
+          echo "$PATH"
+          echo "=== Qt location ==="
+          ls -la "${{github.workspace}}/Qt/bin" || true
+
       - name: Run tests
         shell: cmd
         working-directory: ${{github.workspace}}/build
@@ -316,7 +347,40 @@ jobs:
       - name: Build
         run: cmake --build build --config ${{env.BUILD_TYPE}}
 
+      - name: Debug - Check qztest.exe exists
+        shell: bash
+        working-directory: build
+        run: |
+          echo "=== Searching for qztest.exe ==="
+          find . -name "qztest.exe" -ls || true
+          echo "=== Contents of qztest directory ==="
+          ls -la qztest/ || true
+          ls -la qztest/Release/ || true
+
+      - name: Debug - Try running qztest.exe directly
+        shell: bash
+        working-directory: build
+        continue-on-error: true
+        run: |
+          echo "=== Attempting to run qztest.exe directly ==="
+          if [ -f "qztest/Release/qztest.exe" ]; then
+            echo "Found qztest.exe, attempting to run..."
+            ./qztest/Release/qztest.exe --help || echo "Exit code: $?"
+          else
+            echo "qztest.exe not found in expected location"
+          fi
+
+      - name: Debug - Check environment
+        shell: bash
+        run: |
+          echo "=== PATH ==="
+          echo "$PATH"
+          echo "=== Qt location ==="
+          ls -la "${{github.workspace}}/Qt/bin" || true
+
       - name: Run tests
         shell: cmd
         working-directory: build
+        env:
+          QT_ASSUME_STDERR_HAS_CONSOLE: 1 # !! qDebug() is not visible if this is not set on Win runners
         run: ctest --extra-verbose -C Release

--- a/.github/workflows/qt-zlib.yml
+++ b/.github/workflows/qt-zlib.yml
@@ -214,7 +214,9 @@ jobs:
       - name: Run tests
         shell: cmd
         working-directory: ${{github.workspace}}/build
-        run: ctest --verbose --output-on-failure -C Release
+        env:
+          QT_ASSUME_STDERR_HAS_CONSOLE: 1 # !! qDebug() is not visible if this is not set on Win runners
+        run: ctest --extra-verbose -C Release
 
   use-qt5-zlib-windows:
     if: true

--- a/.github/workflows/qt-zlib.yml
+++ b/.github/workflows/qt-zlib.yml
@@ -24,7 +24,6 @@ jobs:
       fail-fast: false
       matrix:
         qt_version: [ 5.15.12, 6.4.3, 6.8.2 ]
-        locale: [ 'C.UTF-8', 'C' ]
 
     steps:
       - name: Checkout
@@ -38,9 +37,6 @@ jobs:
 
       - name: Run tests
         working-directory: build
-        env:
-          LC_ALL: ${{ matrix.locale }}
-          LANG: ${{ matrix.locale }}
         run: ctest --verbose -C Release
 
   use-qt6-zlib-windows:

--- a/.github/workflows/qt-zlib.yml
+++ b/.github/workflows/qt-zlib.yml
@@ -18,7 +18,7 @@ jobs:
   use-qt-zlib-ubuntu:
     if: true
     runs-on: ubuntu-22.04
-    name: use-qt-zlib-ubuntu-${{ matrix.qt_version }}-${{ matrix.locale }}
+    name: use-qt-zlib-ubuntu-${{ matrix.qt_version }}
     container: ghcr.io/cen1/qt:${{ matrix.qt_version }}
     strategy:
       fail-fast: false
@@ -180,37 +180,6 @@ jobs:
         shell: cmd
         run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
 
-      - name: Debug - Check qztest.exe exists
-        shell: bash
-        working-directory: ${{github.workspace}}/build
-        run: |
-          echo "=== Searching for qztest.exe ==="
-          find . -name "qztest.exe" -ls || true
-          echo "=== Contents of qztest directory ==="
-          ls -la qztest/ || true
-          ls -la qztest/Release/ || true
-
-      - name: Debug - Try running qztest.exe directly
-        shell: bash
-        working-directory: ${{github.workspace}}/build
-        continue-on-error: true
-        run: |
-          echo "=== Attempting to run qztest.exe directly ==="
-          if [ -f "qztest/Release/qztest.exe" ]; then
-            echo "Found qztest.exe, attempting to run..."
-            ./qztest/Release/qztest.exe --help || echo "Exit code: $?"
-          else
-            echo "qztest.exe not found in expected location"
-          fi
-
-      - name: Debug - Check environment
-        shell: bash
-        run: |
-          echo "=== PATH ==="
-          echo "$PATH"
-          echo "=== Qt location ==="
-          ls -la "${{github.workspace}}/Qt/bin" || true
-
       - name: Run tests
         shell: cmd
         working-directory: ${{github.workspace}}/build
@@ -348,37 +317,6 @@ jobs:
 
       - name: Build
         run: cmake --build build --config ${{env.BUILD_TYPE}}
-
-      - name: Debug - Check qztest.exe exists
-        shell: bash
-        working-directory: build
-        run: |
-          echo "=== Searching for qztest.exe ==="
-          find . -name "qztest.exe" -ls || true
-          echo "=== Contents of qztest directory ==="
-          ls -la qztest/ || true
-          ls -la qztest/Release/ || true
-
-      - name: Debug - Try running qztest.exe directly
-        shell: bash
-        working-directory: build
-        continue-on-error: true
-        run: |
-          echo "=== Attempting to run qztest.exe directly ==="
-          if [ -f "qztest/Release/qztest.exe" ]; then
-            echo "Found qztest.exe, attempting to run..."
-            ./qztest/Release/qztest.exe --help || echo "Exit code: $?"
-          else
-            echo "qztest.exe not found in expected location"
-          fi
-
-      - name: Debug - Check environment
-        shell: bash
-        run: |
-          echo "=== PATH ==="
-          echo "$PATH"
-          echo "=== Qt location ==="
-          ls -la "${{github.workspace}}/Qt/bin" || true
 
       - name: Run tests
         shell: cmd

--- a/.github/workflows/qt-zlib.yml
+++ b/.github/workflows/qt-zlib.yml
@@ -18,12 +18,13 @@ jobs:
   use-qt-zlib-ubuntu:
     if: true
     runs-on: ubuntu-22.04
-    name: use-qt-zlib-ubuntu-${{ matrix.qt_version }}
+    name: use-qt-zlib-ubuntu-${{ matrix.qt_version }}-${{ matrix.locale }}
     container: ghcr.io/cen1/qt:${{ matrix.qt_version }}
     strategy:
       fail-fast: false
       matrix:
         qt_version: [ 5.15.12, 6.4.3, 6.8.2 ]
+        locale: [ 'C.UTF-8', 'C' ]
 
     steps:
       - name: Checkout
@@ -37,6 +38,9 @@ jobs:
 
       - name: Run tests
         working-directory: build
+        env:
+          LC_ALL: ${{ matrix.locale }}
+          LANG: ${{ matrix.locale }}
         run: ctest --verbose -C Release
 
   use-qt6-zlib-windows:

--- a/.github/workflows/reusable-win.yml
+++ b/.github/workflows/reusable-win.yml
@@ -36,10 +36,6 @@ on:
         required: false
         default: false
         type: boolean
-      test_utf8_compress_bad:
-        required: false
-        default: false
-        type: boolean
       test_utf8_decompress:
         required: false
         default: false
@@ -136,7 +132,6 @@ jobs:
           TEST_CR_COMPRESS: ${{ inputs.test_cr_compress }}
           TEST_UTF8_COMPRESS: ${{ inputs.test_utf8_compress  }}
           TEST_UTF8_DECOMPRESS: ${{ inputs.test_utf8_decompress  }}
-          TEST_UTF8_COMPRESS_BAD: ${{ inputs.test_utf8_compress_bad }}
           TEST_UTF8_ARCHIVE_TYPE: ${{ inputs.test_utf8_archive_type }}
           #TEST_ZIP_UNZIP_LARGE: true
           QT_ASSUME_STDERR_HAS_CONSOLE: 1 # !! qDebug() is not visible if this is not set on Win runners

--- a/.github/workflows/reusable-win.yml
+++ b/.github/workflows/reusable-win.yml
@@ -118,7 +118,7 @@ jobs:
       - name: Run tests
         if: inputs.run_tests && !inputs.cross_extract
         env:
-          TEST_CR_COMPRESS: ${{ !inputs.test_cr_compress }}
+          TEST_CR_COMPRESS: ${{ inputs.test_cr_compress }}
           TEST_UTF8_COMPRESS: ${{ inputs.test_utf8_compress  }}
           TEST_UTF8_COMPRESS_BAD: ${{ inputs.test_utf8_compress_bad }}
           #TEST_ZIP_UNZIP_LARGE: true

--- a/.github/workflows/reusable-win.yml
+++ b/.github/workflows/reusable-win.yml
@@ -44,6 +44,10 @@ on:
         required: false
         default: false
         type: boolean
+      test_utf8_archive_type:
+        required: false
+        default: "with_flag"
+        type: string
     secrets:
       GH_TOKEN:
         required: false
@@ -133,6 +137,7 @@ jobs:
           TEST_UTF8_COMPRESS: ${{ inputs.test_utf8_compress  }}
           TEST_UTF8_DECOMPRESS: ${{ inputs.test_utf8_decompress  }}
           TEST_UTF8_COMPRESS_BAD: ${{ inputs.test_utf8_compress_bad }}
+          TEST_UTF8_ARCHIVE_TYPE: ${{ inputs.test_utf8_archive_type }}
           #TEST_ZIP_UNZIP_LARGE: true
           QT_ASSUME_STDERR_HAS_CONSOLE: 1 # !! qDebug() is not visible if this is not set on Win runners
         working-directory: ./build

--- a/.github/workflows/reusable-win.yml
+++ b/.github/workflows/reusable-win.yml
@@ -40,6 +40,10 @@ on:
         required: false
         default: false
         type: boolean
+      test_utf8_decompress:
+        required: false
+        default: false
+        type: boolean
     secrets:
       GH_TOKEN:
         required: false
@@ -115,11 +119,19 @@ jobs:
           file "$DLL_NAME"
           file "$DLL_NAME" |grep "${{ inputs.pe_str }}"
 
+      - name: Download UTF-8 archives
+        if: inputs.test_utf8_decompress
+        uses: actions/download-artifact@v4
+        with:
+          path: build/quazip
+          merge-multiple: false
+
       - name: Run tests
         if: inputs.run_tests && !inputs.cross_extract
         env:
           TEST_CR_COMPRESS: ${{ inputs.test_cr_compress }}
           TEST_UTF8_COMPRESS: ${{ inputs.test_utf8_compress  }}
+          TEST_UTF8_DECOMPRESS: ${{ inputs.test_utf8_decompress  }}
           TEST_UTF8_COMPRESS_BAD: ${{ inputs.test_utf8_compress_bad }}
           #TEST_ZIP_UNZIP_LARGE: true
           QT_ASSUME_STDERR_HAS_CONSOLE: 1 # !! qDebug() is not visible if this is not set on Win runners

--- a/.github/workflows/reusable-win.yml
+++ b/.github/workflows/reusable-win.yml
@@ -115,8 +115,8 @@ jobs:
         if: inputs.run_tests && !inputs.cross_extract
         env:
           TEST_CR_COMPRESS: "true"
-          TEST_UTF8_COMPRESS: ${{ inputs.test_utf8_compress }}
-          TEST_UTF8_COMPRESS_BAD: ${{ inputs.test_utf8_compress_bad }}
+          TEST_UTF8_COMPRESS: ${{ inputs.test_utf8_compress && 'true' || 'false' }}
+          TEST_UTF8_COMPRESS_BAD: ${{ inputs.test_utf8_compress_bad && 'true' || 'false' }}
           #TEST_ZIP_UNZIP_LARGE: true
           QT_ASSUME_STDERR_HAS_CONSOLE: 1 # !! qDebug() is not visible if this is not set on Win runners
         working-directory: ./build

--- a/.github/workflows/reusable-win.yml
+++ b/.github/workflows/reusable-win.yml
@@ -28,6 +28,10 @@ on:
         required: false
         default: false
         type: boolean
+      test_cr_compress:
+        required: false
+        default: true
+        type: boolean
       test_utf8_compress:
         required: false
         default: false
@@ -114,9 +118,9 @@ jobs:
       - name: Run tests
         if: inputs.run_tests && !inputs.cross_extract
         env:
-          TEST_CR_COMPRESS: "true"
-          TEST_UTF8_COMPRESS: ${{ inputs.test_utf8_compress && 'true' || 'false' }}
-          TEST_UTF8_COMPRESS_BAD: ${{ inputs.test_utf8_compress_bad && 'true' || 'false' }}
+          TEST_CR_COMPRESS: ${{ !inputs.test_cr_compress }}
+          TEST_UTF8_COMPRESS: ${{ inputs.test_utf8_compress  }}
+          TEST_UTF8_COMPRESS_BAD: ${{ inputs.test_utf8_compress_bad }}
           #TEST_ZIP_UNZIP_LARGE: true
           QT_ASSUME_STDERR_HAS_CONSOLE: 1 # !! qDebug() is not visible if this is not set on Win runners
         working-directory: ./build

--- a/.github/workflows/reusable-win.yml
+++ b/.github/workflows/reusable-win.yml
@@ -28,6 +28,14 @@ on:
         required: false
         default: false
         type: boolean
+      test_utf8_compress:
+        required: false
+        default: false
+        type: boolean
+      test_utf8_compress_bad:
+        required: false
+        default: false
+        type: boolean
     secrets:
       GH_TOKEN:
         required: false
@@ -107,6 +115,8 @@ jobs:
         if: inputs.run_tests && !inputs.cross_extract
         env:
           TEST_CR_COMPRESS: "true"
+          TEST_UTF8_COMPRESS: ${{ inputs.test_utf8_compress }}
+          TEST_UTF8_COMPRESS_BAD: ${{ inputs.test_utf8_compress_bad }}
           #TEST_ZIP_UNZIP_LARGE: true
           QT_ASSUME_STDERR_HAS_CONSOLE: 1 # !! qDebug() is not visible if this is not set on Win runners
         working-directory: ./build

--- a/.github/workflows/utf8.yml
+++ b/.github/workflows/utf8.yml
@@ -96,24 +96,24 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install and generate Latin1 locale
-        run: |
-          apt-get update
-          apt-get install -y locales
-          locale-gen en_US.ISO-8859-1
-          locale -a
-
       - name: Configure CMake
         run: cmake -DCMAKE_BUILD_TYPE="${{env.BUILD_TYPE}}" -DBUILD_SHARED_LIBS=OFF -DQUAZIP_ENABLE_TESTS=ON -DQUAZIP_USE_QT_ZLIB=ON -DCMAKE_PREFIX_PATH="/usr/local/Qt-${{ matrix.qt_version }}" -B build
 
       - name: Build
         run: cmake --build build --config ${{env.BUILD_TYPE}}
 
+      - name: Setup Latin-1 locale
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y locales
+          echo "de_DE ISO-8859-1" | sudo tee -a /etc/locale.gen
+          sudo locale-gen
+
       - name: Compress UTF-8 filenames WITHOUT UTF-8 flag in Latin1 locale
         working-directory: build
         env:
-          LC_ALL: en_US.ISO-8859-1
-          LANG: en_US.ISO-8859-1
+          LC_ALL: de_DE ISO-8859-1
+          LANG: de_DE ISO-8859-1
           TEST_UTF8_COMPRESS: "true"
           TEST_UTF8_COMPRESS_BAD: "true"
         run: ctest --verbose -C Release

--- a/.github/workflows/utf8.yml
+++ b/.github/workflows/utf8.yml
@@ -106,8 +106,8 @@ jobs:
         run: |
           apt-get update
           apt-get install -y locales
-          echo "de_DE ISO-8859-1" | sudo tee -a /etc/locale.gen
-          sudo locale-gen
+          echo "de_DE ISO-8859-1" | tee -a /etc/locale.gen
+          locale-gen
 
       - name: Compress UTF-8 filenames WITHOUT UTF-8 flag in Latin1 locale
         working-directory: build

--- a/.github/workflows/utf8.yml
+++ b/.github/workflows/utf8.yml
@@ -56,8 +56,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           retention-days: 1
-          overwrite: true
-          name: "utf8_archives_qt${{ matrix.qt_version }}"
+          name: "utf8_${{ matrix.flag_type }}_qt${{ matrix.qt_version }}"
           path: build/quazip/${{ matrix.archive_pattern }}
 
   # ============================================================================

--- a/.github/workflows/utf8.yml
+++ b/.github/workflows/utf8.yml
@@ -23,14 +23,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        qt_version: [ 6.8.2 ]
+        qt_version: [ 5.15.12, 6.4.3, 6.8.2 ]
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
       - name: Configure CMake
-        run: cmake -DCMAKE_BUILD_TYPE="${{env.BUILD_TYPE}}" -DBUILD_SHARED_LIBS=OFF -DQUAZIP_ENABLE_TESTS=ON -DCMAKE_PREFIX_PATH="/usr/local/Qt-${{ matrix.qt_version }}" -B build
+        run: cmake -DCMAKE_BUILD_TYPE="${{env.BUILD_TYPE}}" -DBUILD_SHARED_LIBS=OFF -DQUAZIP_ENABLE_TESTS=ON -DQUAZIP_USE_QT_ZLIB=ON -DCMAKE_PREFIX_PATH="/usr/local/Qt-${{ matrix.qt_version }}" -B build
 
       - name: Build
         run: cmake --build build --config ${{env.BUILD_TYPE}}
@@ -61,14 +61,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        qt_version: [ 6.8.2 ]
+        qt_version: [ 5.15.12, 6.4.3, 6.8.2 ]
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
       - name: Configure CMake
-        run: cmake -DCMAKE_BUILD_TYPE="${{env.BUILD_TYPE}}" -DBUILD_SHARED_LIBS=OFF -DQUAZIP_ENABLE_TESTS=ON -DCMAKE_PREFIX_PATH="/usr/local/Qt-${{ matrix.qt_version }}" -B build
+        run: cmake -DCMAKE_BUILD_TYPE="${{env.BUILD_TYPE}}" -DBUILD_SHARED_LIBS=OFF -DQUAZIP_ENABLE_TESTS=ON -DQUAZIP_USE_QT_ZLIB=ON -DCMAKE_PREFIX_PATH="/usr/local/Qt-${{ matrix.qt_version }}" -B build
 
       - name: Build
         run: cmake --build build --config ${{env.BUILD_TYPE}}

--- a/.github/workflows/utf8.yml
+++ b/.github/workflows/utf8.yml
@@ -81,6 +81,60 @@ jobs:
           TEST_UTF8_COMPRESS_BAD: "true"
         run: ctest --verbose -C Release
 
+  # Compression job with Latin1 locale - demonstrates '?' replacement vs character dropping
+  utf8-compress-bad-latin1:
+    if: true
+    runs-on: ubuntu-22.04
+    name: utf8-compress-bad-latin1-Qt-${{ matrix.qt_version }}
+    container: ghcr.io/cen1/qt:${{ matrix.qt_version }}
+    strategy:
+      fail-fast: false
+      matrix:
+        qt_version: [ 5.15.12 ]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install and generate Latin1 locale
+        run: |
+          apt-get update
+          apt-get install -y locales
+          locale-gen en_US.ISO-8859-1
+          locale -a
+
+      - name: Configure CMake
+        run: cmake -DCMAKE_BUILD_TYPE="${{env.BUILD_TYPE}}" -DBUILD_SHARED_LIBS=OFF -DQUAZIP_ENABLE_TESTS=ON -DQUAZIP_USE_QT_ZLIB=ON -DCMAKE_PREFIX_PATH="/usr/local/Qt-${{ matrix.qt_version }}" -B build
+
+      - name: Build
+        run: cmake --build build --config ${{env.BUILD_TYPE}}
+
+      - name: Compress UTF-8 filenames WITHOUT UTF-8 flag in Latin1 locale
+        working-directory: build
+        env:
+          LC_ALL: en_US.ISO-8859-1
+          LANG: en_US.ISO-8859-1
+          TEST_UTF8_COMPRESS: "true"
+          TEST_UTF8_COMPRESS_BAD: "true"
+        run: ctest --verbose -C Release
+
+  utf8-compress-bad-win-x64:
+    name: Win-Qt-${{ matrix.qt_version }}-preset-${{ matrix.preset }}
+    strategy:
+      fail-fast: false
+      matrix:
+        preset: [ conan ]
+        qt_version: [ 5.15.2, 6.8.2 ]
+    uses: ./.github/workflows/reusable-win.yml
+    with:
+      runs_on: "win-x64"
+      arch: x64
+      qt_version: ${{ matrix.qt_version }}
+      preset: ${{ matrix.preset }}
+      pe_str: "x86-64"
+      test_utf8_compress: true
+      test_utf8_compress_bad: true
+
   # Decompression job - extracts UTF-8 archives with C locale, expects mangled output
   utf8-decompress:
     if: true

--- a/.github/workflows/utf8.yml
+++ b/.github/workflows/utf8.yml
@@ -104,8 +104,8 @@ jobs:
 
       - name: Setup Latin-1 locale
         run: |
-          sudo apt-get update
-          sudo apt-get install -y locales
+          apt-get update
+          apt-get install -y locales
           echo "de_DE ISO-8859-1" | sudo tee -a /etc/locale.gen
           sudo locale-gen
 

--- a/.github/workflows/utf8.yml
+++ b/.github/workflows/utf8.yml
@@ -171,3 +171,20 @@ jobs:
           LANG: C
           TEST_UTF8_DECOMPRESS: "true"
         run: ctest --verbose -C Release
+
+  utf8-decompress-win-64:
+    name: Win-Qt-${{ matrix.qt_version }}-preset-${{ matrix.preset }}
+    strategy:
+      fail-fast: false
+      matrix:
+        preset: [ conan ]
+        qt_version: [ 5.15.2, 6.8.2 ]
+    uses: ./.github/workflows/reusable-win.yml
+    with:
+      runs_on: "win-x64"
+      arch: x64
+      qt_version: ${{ matrix.qt_version }}
+      preset: ${{ matrix.preset }}
+      pe_str: "x86-64"
+      test_cr_compress: false
+      test_utf8_decompress: true

--- a/.github/workflows/utf8.yml
+++ b/.github/workflows/utf8.yml
@@ -1,0 +1,88 @@
+on:
+  push:
+    branches:
+      - master
+      - feature/*
+  pull_request:
+  workflow_dispatch:
+
+name: UTF-8 Filename Tests
+
+permissions: read-all
+
+env:
+  BUILD_TYPE: Release
+
+jobs:
+  # Compression job - creates UTF-8 archives with UTF-8 locale
+  utf8-compress:
+    if: true
+    runs-on: ubuntu-22.04
+    name: utf8-compress-Qt-${{ matrix.qt_version }}
+    container: ghcr.io/cen1/qt:${{ matrix.qt_version }}
+    strategy:
+      fail-fast: false
+      matrix:
+        qt_version: [ 6.8.2 ]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure CMake
+        run: cmake -DCMAKE_BUILD_TYPE="${{env.BUILD_TYPE}}" -DBUILD_SHARED_LIBS=OFF -DQUAZIP_ENABLE_TESTS=ON -DCMAKE_PREFIX_PATH="/usr/local/Qt-${{ matrix.qt_version }}" -B build
+
+      - name: Build
+        run: cmake --build build --config ${{env.BUILD_TYPE}}
+
+      - name: Run UTF-8 compression tests
+        working-directory: build
+        env:
+          LC_ALL: C.UTF-8
+          LANG: C.UTF-8
+          TEST_UTF8_COMPRESS: "true"
+        run: ctest --verbose -C Release
+
+      - name: Upload UTF-8 archives to GitHub Actions Storage
+        uses: actions/upload-artifact@v4
+        with:
+          retention-days: 1
+          overwrite: true
+          name: "utf8_archives_qt${{ matrix.qt_version }}"
+          path: build/quazip/utf8_*.zip
+
+  # Decompression job - extracts UTF-8 archives with C locale, expects mangled output
+  utf8-decompress:
+    if: true
+    runs-on: ubuntu-22.04
+    name: utf8-decompress-Qt-${{ matrix.qt_version }}
+    container: ghcr.io/cen1/qt:${{ matrix.qt_version }}
+    needs: [ utf8-compress ]
+    strategy:
+      fail-fast: false
+      matrix:
+        qt_version: [ 6.8.2 ]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure CMake
+        run: cmake -DCMAKE_BUILD_TYPE="${{env.BUILD_TYPE}}" -DBUILD_SHARED_LIBS=OFF -DQUAZIP_ENABLE_TESTS=ON -DCMAKE_PREFIX_PATH="/usr/local/Qt-${{ matrix.qt_version }}" -B build
+
+      - name: Build
+        run: cmake --build build --config ${{env.BUILD_TYPE}}
+
+      - name: Download UTF-8 archives
+        uses: actions/download-artifact@v4
+        with:
+          path: build/quazip
+          merge-multiple: false
+
+      - name: Run UTF-8 decompression tests
+        working-directory: build
+        env:
+          LC_ALL: C
+          LANG: C
+          TEST_UTF8_DECOMPRESS: "true"
+        run: ctest --verbose -C Release

--- a/.github/workflows/utf8.yml
+++ b/.github/workflows/utf8.yml
@@ -14,16 +14,24 @@ env:
   BUILD_TYPE: Release
 
 jobs:
-  # Compression job - creates UTF-8 archives with UTF-8 locale
+  # Compression job - creates UTF-8 archives on UTF-8 locale system
+  # Creates TWO types of archives: with UTF-8 flag and without UTF-8 flag
   utf8-compress:
-    if: true
     runs-on: ubuntu-22.04
-    name: utf8-compress-Qt-${{ matrix.qt_version }}
+    name: compress-${{ matrix.flag_type }}-Qt-${{ matrix.qt_version }}
     container: ghcr.io/cen1/qt:${{ matrix.qt_version }}
     strategy:
       fail-fast: false
       matrix:
-        qt_version: [ 5.15.12, 6.4.3, 6.8.2 ]
+        qt_version: [ 6.8.2 ]
+        flag_type: [ "with_flag", "no_flag" ]
+        include:
+          - flag_type: "with_flag"
+            flag_value: "true"
+            archive_pattern: "utf8_with_flag_*.zip"
+          - flag_type: "no_flag"
+            flag_value: "false"
+            archive_pattern: "utf8_no_flag_*.zip"
 
     steps:
       - name: Checkout
@@ -35,62 +43,74 @@ jobs:
       - name: Build
         run: cmake --build build --config ${{env.BUILD_TYPE}}
 
-      - name: Run UTF-8 compression tests
+      - name: Create UTF-8 archives (${{ matrix.flag_type }})
         working-directory: build
         env:
           LC_ALL: C.UTF-8
           LANG: C.UTF-8
           TEST_UTF8_COMPRESS: "true"
+          TEST_UTF8_WITH_FLAG: ${{ matrix.flag_value }}
         run: ctest --verbose -C Release
 
-      - name: Upload UTF-8 archives to GitHub Actions Storage
+      - name: Upload archives (${{ matrix.flag_type }})
         uses: actions/upload-artifact@v4
         with:
           retention-days: 1
           overwrite: true
           name: "utf8_archives_qt${{ matrix.qt_version }}"
-          path: build/quazip/utf8_*.zip
+          path: build/quazip/${{ matrix.archive_pattern }}
 
-  # Compression job with C locale - demonstrates filename mangling when UTF-8 flag is not used
-  utf8-compress-bad:
-    if: true
+  # ============================================================================
+  # DECOMPRESSION TESTS - Linux
+  # Test various archive types, Qt versions, and locales
+  # ============================================================================
+
+  decompress-linux:
     runs-on: ubuntu-22.04
-    name: utf8-compress-bad-Qt-${{ matrix.qt_version }}
+    name: decompress-Linux-${{ matrix.name }}
     container: ghcr.io/cen1/qt:${{ matrix.qt_version }}
+    needs: [utf8-compress]
     strategy:
       fail-fast: false
       matrix:
-        qt_version: [ 5.15.12, 6.8.2 ]
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Configure CMake
-        run: cmake -DCMAKE_BUILD_TYPE="${{env.BUILD_TYPE}}" -DBUILD_SHARED_LIBS=OFF -DQUAZIP_ENABLE_TESTS=ON -DQUAZIP_USE_QT_ZLIB=ON -DCMAKE_PREFIX_PATH="/usr/local/Qt-${{ matrix.qt_version }}" -B build
-
-      - name: Build
-        run: cmake --build build --config ${{env.BUILD_TYPE}}
-
-      - name: Compress UTF-8 filenames WITHOUT UTF-8 flag in C locale
-        working-directory: build
-        env:
-          LC_ALL: C
-          LANG: C
-          TEST_UTF8_COMPRESS: "true"
-          TEST_UTF8_COMPRESS_BAD: "true"
-        run: ctest --verbose -C Release
-
-  # Compression job with Latin1 locale - demonstrates '?' replacement vs character dropping
-  utf8-compress-bad-latin1:
-    if: true
-    runs-on: ubuntu-22.04
-    name: utf8-compress-bad-latin1-Qt-${{ matrix.qt_version }}
-    container: ghcr.io/cen1/qt:${{ matrix.qt_version }}
-    strategy:
-      fail-fast: false
-      matrix:
-        qt_version: [ 5.15.12 ]
+        include:
+          # Archives WITH UTF-8 flag - should always work
+          - name: "with-flag-Qt5"
+            qt_version: "5.15.12"
+            archive_type: "with_flag"
+            setup_locale: false
+            lc_all: "C"
+            lang: "C"
+            test_description: "with flag (should work)"
+          - name: "with-flag-Qt6"
+            qt_version: "6.8.2"
+            archive_type: "with_flag"
+            setup_locale: false
+            lc_all: "C"
+            lang: "C"
+            test_description: "with flag (should work)"
+          # Archives WITHOUT UTF-8 flag - behavior depends on Qt version/locale
+          - name: "no-flag-Qt5-UTF8-locale"
+            qt_version: "5.15.12"
+            archive_type: "no_flag"
+            setup_locale: false
+            lc_all: "C.UTF-8"
+            lang: "C.UTF-8"
+            test_description: "no flag, UTF-8 locale = works"
+          - name: "no-flag-Qt5-Latin1-locale"
+            qt_version: "5.15.12"
+            archive_type: "no_flag"
+            setup_locale: true
+            lc_all: "de_DE ISO-8859-1"
+            lang: "de_DE ISO-8859-1"
+            test_description: "no flag, Latin1 = null truncation"
+          - name: "no-flag-Qt6"
+            qt_version: "6.8.2"
+            archive_type: "no_flag"
+            setup_locale: false
+            lc_all: "C"
+            lang: "C"
+            test_description: "no flag, Qt6 forces UTF-8 = works"
 
     steps:
       - name: Checkout
@@ -103,60 +123,12 @@ jobs:
         run: cmake --build build --config ${{env.BUILD_TYPE}}
 
       - name: Setup Latin-1 locale
+        if: matrix.setup_locale
         run: |
           apt-get update
           apt-get install -y locales
           echo "de_DE ISO-8859-1" | tee -a /etc/locale.gen
           locale-gen
-
-      - name: Compress UTF-8 filenames WITHOUT UTF-8 flag in Latin1 locale
-        working-directory: build
-        env:
-          LC_ALL: de_DE ISO-8859-1
-          LANG: de_DE ISO-8859-1
-          TEST_UTF8_COMPRESS: "true"
-          TEST_UTF8_COMPRESS_BAD: "true"
-        run: ctest --verbose -C Release
-
-  utf8-compress-bad-win-x64:
-    name: Win-Qt-${{ matrix.qt_version }}-preset-${{ matrix.preset }}
-    strategy:
-      fail-fast: false
-      matrix:
-        preset: [ conan ]
-        qt_version: [ 5.15.2, 6.8.2 ]
-    uses: ./.github/workflows/reusable-win.yml
-    with:
-      runs_on: "win-x64"
-      arch: x64
-      qt_version: ${{ matrix.qt_version }}
-      preset: ${{ matrix.preset }}
-      pe_str: "x86-64"
-      test_cr_compress: false
-      test_utf8_compress: true
-      test_utf8_compress_bad: true
-
-  # Decompression job - extracts UTF-8 archives with C locale, expects mangled output
-  utf8-decompress:
-    if: true
-    runs-on: ubuntu-22.04
-    name: utf8-decompress-Qt-${{ matrix.qt_version }}
-    container: ghcr.io/cen1/qt:${{ matrix.qt_version }}
-    needs: [ utf8-compress ]
-    strategy:
-      fail-fast: false
-      matrix:
-        qt_version: [ 5.15.12, 6.4.3, 6.8.2 ]
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Configure CMake
-        run: cmake -DCMAKE_BUILD_TYPE="${{env.BUILD_TYPE}}" -DBUILD_SHARED_LIBS=OFF -DQUAZIP_ENABLE_TESTS=ON -DQUAZIP_USE_QT_ZLIB=ON -DCMAKE_PREFIX_PATH="/usr/local/Qt-${{ matrix.qt_version }}" -B build
-
-      - name: Build
-        run: cmake --build build --config ${{env.BUILD_TYPE}}
 
       - name: Download UTF-8 archives
         uses: actions/download-artifact@v4
@@ -164,21 +136,24 @@ jobs:
           path: build/quazip
           merge-multiple: false
 
-      - name: Run UTF-8 decompression tests
+      - name: Extract UTF-8 archives (${{ matrix.test_description }})
         working-directory: build
         env:
-          LC_ALL: C
-          LANG: C
+          LC_ALL: ${{ matrix.lc_all }}
+          LANG: ${{ matrix.lang }}
           TEST_UTF8_DECOMPRESS: "true"
+          TEST_UTF8_ARCHIVE_TYPE: ${{ matrix.archive_type }}
         run: ctest --verbose -C Release
 
-  utf8-decompress-win-64:
-    name: Win-Qt-${{ matrix.qt_version }}-preset-${{ matrix.preset }}
+  decompress-windows:
+    name: decompress-Win-${{ matrix.archive_type }}-Qt-${{ matrix.qt_version }}
+    needs: [utf8-compress]
     strategy:
       fail-fast: false
       matrix:
         preset: [ conan ]
         qt_version: [ 5.15.2, 6.8.2 ]
+        archive_type: [ "with_flag", "no_flag" ]
     uses: ./.github/workflows/reusable-win.yml
     with:
       runs_on: "win-x64"
@@ -188,3 +163,47 @@ jobs:
       pe_str: "x86-64"
       test_cr_compress: false
       test_utf8_decompress: true
+      test_utf8_archive_type: ${{ matrix.archive_type }}
+
+  decompress-macos:
+    runs-on: macos-${{ matrix.os_version }}
+    name: decompress-macOS-${{ matrix.os_version }}-${{ matrix.archive_type }}-Qt-${{ matrix.qt_version }}
+    needs: [utf8-compress]
+    strategy:
+      fail-fast: false
+      matrix:
+        os_version: [ 15 ]
+        qt_version: [ 6.8.2 ]
+        archive_type: [ "with_flag", "no_flag" ]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Qt
+        uses: jurplel/install-qt-action@v3
+        with:
+          version: ${{ matrix.qt_version }}
+          cache: 'true'
+          cache-key-prefix: macOS-Qt-Cache-${{ matrix.qt_version }}
+          dir: ${{ github.workspace }}/Qt
+          modules: 'qt5compat'
+
+      - name: Configure CMake
+        run: cmake -DCMAKE_BUILD_TYPE="${{env.BUILD_TYPE}}" -DBUILD_SHARED_LIBS=OFF -DQUAZIP_ENABLE_TESTS=ON -B "${{github.workspace}}/build"
+
+      - name: Build
+        run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+
+      - name: Download UTF-8 archives
+        uses: actions/download-artifact@v4
+        with:
+          path: build/quazip
+          merge-multiple: false
+
+      - name: Extract UTF-8 archives (${{ matrix.archive_type }})
+        working-directory: build
+        env:
+          TEST_UTF8_DECOMPRESS: "true"
+          TEST_UTF8_ARCHIVE_TYPE: ${{ matrix.archive_type }}
+        run: ctest --verbose -C Release

--- a/.github/workflows/utf8.yml
+++ b/.github/workflows/utf8.yml
@@ -51,6 +51,36 @@ jobs:
           name: "utf8_archives_qt${{ matrix.qt_version }}"
           path: build/quazip/utf8_*.zip
 
+  # Compression job with C locale - demonstrates filename mangling when UTF-8 flag is not used
+  utf8-compress-bad:
+    if: true
+    runs-on: ubuntu-22.04
+    name: utf8-compress-bad-Qt-${{ matrix.qt_version }}
+    container: ghcr.io/cen1/qt:${{ matrix.qt_version }}
+    strategy:
+      fail-fast: false
+      matrix:
+        qt_version: [ 5.15.12, 6.8.2 ]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure CMake
+        run: cmake -DCMAKE_BUILD_TYPE="${{env.BUILD_TYPE}}" -DBUILD_SHARED_LIBS=OFF -DQUAZIP_ENABLE_TESTS=ON -DQUAZIP_USE_QT_ZLIB=ON -DCMAKE_PREFIX_PATH="/usr/local/Qt-${{ matrix.qt_version }}" -B build
+
+      - name: Build
+        run: cmake --build build --config ${{env.BUILD_TYPE}}
+
+      - name: Compress UTF-8 filenames WITHOUT UTF-8 flag in C locale
+        working-directory: build
+        env:
+          LC_ALL: C
+          LANG: C
+          TEST_UTF8_COMPRESS: "true"
+          TEST_UTF8_COMPRESS_BAD: "true"
+        run: ctest --verbose -C Release
+
   # Decompression job - extracts UTF-8 archives with C locale, expects mangled output
   utf8-decompress:
     if: true

--- a/.github/workflows/utf8.yml
+++ b/.github/workflows/utf8.yml
@@ -132,6 +132,7 @@ jobs:
       qt_version: ${{ matrix.qt_version }}
       preset: ${{ matrix.preset }}
       pe_str: "x86-64"
+      test_cr_compress: false
       test_utf8_compress: true
       test_utf8_compress_bad: true
 

--- a/.github/workflows/utf8.yml
+++ b/.github/workflows/utf8.yml
@@ -73,21 +73,22 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Archives WITH UTF-8 flag - should always work
-          - name: "with-flag-Qt5"
+          # Archives WITH UTF-8 flag
+          # Note: Qt 5 still requires UTF-8 locale even with flag set
+          - name: "with-flag-Qt5-UTF8-locale"
             qt_version: "5.15.12"
             archive_type: "with_flag"
             setup_locale: false
-            lc_all: "C"
-            lang: "C"
-            test_description: "with flag (should work)"
+            lc_all: "C.UTF-8"
+            lang: "C.UTF-8"
+            test_description: "with flag, Qt5 + UTF-8 locale = works"
           - name: "with-flag-Qt6"
             qt_version: "6.8.2"
             archive_type: "with_flag"
             setup_locale: false
             lc_all: "C"
             lang: "C"
-            test_description: "with flag (should work)"
+            test_description: "with flag, Qt6 = works"
           # Archives WITHOUT UTF-8 flag - behavior depends on Qt version/locale
           - name: "no-flag-Qt5-UTF8-locale"
             qt_version: "5.15.12"
@@ -96,6 +97,13 @@ jobs:
             lc_all: "C.UTF-8"
             lang: "C.UTF-8"
             test_description: "no flag, UTF-8 locale = works"
+          - name: "no-flag-Qt5-C-locale"
+            qt_version: "5.15.12"
+            archive_type: "no_flag"
+            setup_locale: false
+            lc_all: "C"
+            lang: "C"
+            test_description: "no flag, C locale = null truncation"
           - name: "no-flag-Qt5-Latin1-locale"
             qt_version: "5.15.12"
             archive_type: "no_flag"

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -1,0 +1,172 @@
+# Example Usage
+
+QuaZip provides three API levels with increasing abstraction. Choose the one that best fits your needs.
+
+## Low-Level API (QuaZip/QuaZipFile)
+
+Use when you need fine-grained control over ZIP operations or stream-based processing.
+
+### Compress
+
+```cpp
+#include <QuaZip.h>
+#include <QuaZipFile.h>
+#include <QFile>
+
+// Create a ZIP archive and add a file
+QuaZip zip("archive.zip");
+if (!zip.open(QuaZip::mdCreate)) {
+    // Handle error
+    return;
+}
+
+QFile inFile("document.txt");
+if (!inFile.open(QIODevice::ReadOnly)) {
+    return;
+}
+
+QuaZipFile outFile(&zip);
+if (!outFile.open(QIODevice::WriteOnly, QuaZipNewInfo("document.txt"))) {
+    return;
+}
+
+// Copy data
+outFile.write(inFile.readAll());
+
+outFile.close();
+inFile.close();
+zip.close();
+```
+
+### Extract
+
+```cpp
+#include <QuaZip.h>
+#include <QuaZipFile.h>
+#include <QFile>
+
+// Open ZIP archive and extract a file
+QuaZip zip("archive.zip");
+if (!zip.open(QuaZip::mdUnzip)) {
+    return;
+}
+
+zip.setCurrentFile("document.txt");
+
+QuaZipFile inFile(&zip);
+if (!inFile.open(QIODevice::ReadOnly)) {
+    return;
+}
+
+QFile outFile("extracted_document.txt");
+if (!outFile.open(QIODevice::WriteOnly)) {
+    return;
+}
+
+outFile.write(inFile.readAll());
+
+outFile.close();
+inFile.close();
+zip.close();
+```
+
+## JlCompress API
+
+Use for simple, common operations with static utility functions.
+
+### Compress
+
+```cpp
+#include <JlCompress.h>
+
+// Compress a single file
+bool ok = JlCompress::compressFile("archive.zip", "document.txt");
+
+// Compress multiple files
+QStringList files = {"file1.txt", "file2.txt", "file3.txt"};
+ok = JlCompress::compressFiles("archive.zip", files);
+
+// Compress entire directory
+ok = JlCompress::compressDir("archive.zip", "my_folder", true);
+
+// Compress with options (compression level, UTF-8, encryption)
+JlCompress::Options opts(QDateTime(), JlCompress::Options::Best, true, QByteArray("password123"));
+ok = JlCompress::compressFile("archive.zip", "document.txt", opts);
+```
+
+### Extract
+
+```cpp
+#include <JlCompress.h>
+
+// Extract a single file
+QString extracted = JlCompress::extractFile("archive.zip", "document.txt", "output.txt");
+
+// Extract specific files
+QStringList files = {"file1.txt", "file2.txt"};
+QStringList extracted = JlCompress::extractFiles("archive.zip", files, "output_dir");
+
+// Extract entire archive
+QStringList extracted = JlCompress::extractDir("archive.zip", "output_dir");
+
+// Extract encrypted archive
+QString extracted = JlCompress::extractFile("archive.zip", "document.txt", "output.txt", QByteArray("password123"));
+```
+
+## QuaCompress API
+
+Use for readable, fluent chaining of operations with sensible defaults.
+
+### Compress
+
+```cpp
+#include <QuaCompress.h>
+
+// Simple compression with fluent API
+bool ok = QuaCompress()
+    .compressFile("archive.zip", "document.txt");
+
+// Chain multiple options
+ok = QuaCompress()
+    .withUtf8Enabled(true)
+    .withCompression(JlCompress::Options::Best)
+    .withPassword(QByteArray("password123"))
+    .compressFile("archive.zip", "document.txt");
+
+// Compress directory with options
+ok = QuaCompress()
+    .withUtf8Enabled(true)
+    .withCompression(JlCompress::Options::Better)
+    .compressDir("archive.zip", "my_folder", true);
+```
+
+### Extract
+
+```cpp
+#include <QuaCompress.h>
+
+// Simple extraction
+QStringList files = QuaCompress()
+    .extractDir("archive.zip", "output_dir");
+
+// Extract with password using fluent API
+files = QuaCompress()
+    .withPassword(QByteArray("password123"))
+    .extractDir("archive.zip", "output_dir");
+
+// Or pass password as parameter
+files = QuaCompress()
+    .extractDir("archive.zip", "output_dir", QByteArray("password123"));
+
+// Get file list
+QStringList fileNames = QuaCompress()
+    .getFileList("archive.zip");
+```
+
+## Choosing the Right API
+
+- **Low-Level API**: Use when you need streaming I/O, custom error handling, or per-file control.
+- **JlCompress**: Use for simple, one-line operations; static utility pattern.
+- **QuaCompress**: Use when you want readable code with method chaining and discoverable options.
+
+All three APIs support UTF-8 filenames, password encryption, and multiple compression levels. JlCompress and QuaCompress provide built-in path traversal protection when extracting archives.

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -26,7 +26,8 @@ if (!inFile.open(QIODevice::ReadOnly)) {
 }
 
 QuaZipFile outFile(&zip);
-if (!outFile.open(QIODevice::WriteOnly, QuaZipNewInfo("document.txt"))) {
+// QuaZipNewInfo(name, file): name in archive, file to read metadata from
+if (!outFile.open(QIODevice::WriteOnly, QuaZipNewInfo(inFile.fileName(), inFile.fileName()))) {
     return;
 }
 
@@ -44,29 +45,43 @@ zip.close();
 #include <QuaZip.h>
 #include <QuaZipFile.h>
 #include <QFile>
+#include <QDir>
 
-// Open ZIP archive and extract a file
+// Open ZIP archive and extract all files
 QuaZip zip("archive.zip");
 if (!zip.open(QuaZip::mdUnzip)) {
     return;
 }
 
-zip.setCurrentFile("document.txt");
+// Loop through all files in the archive
+for (bool more = zip.goToFirstFile(); more; more = zip.goToNextFile()) {
+    QuaZipFile inFile(&zip);
+    if (!inFile.open(QIODevice::ReadOnly)) {
+        return;
+    }
 
-QuaZipFile inFile(&zip);
-if (!inFile.open(QIODevice::ReadOnly)) {
-    return;
+    // Get current file info to get the filename
+    QuaZipFileInfo64 fileInfo;
+    if (!zip.getCurrentFileInfo(&fileInfo)) {
+        return;
+    }
+
+    // Create output file
+    QString outPath = "output/" + fileInfo.name;
+    QDir().mkpath(QFileInfo(outPath).absolutePath());  // Create directories if needed
+
+    QFile outFile(outPath);
+    if (!outFile.open(QIODevice::WriteOnly)) {
+        return;
+    }
+
+    // Copy data
+    outFile.write(inFile.readAll());
+
+    outFile.close();
+    inFile.close();
 }
 
-QFile outFile("extracted_document.txt");
-if (!outFile.open(QIODevice::WriteOnly)) {
-    return;
-}
-
-outFile.write(inFile.readAll());
-
-outFile.close();
-inFile.close();
 zip.close();
 ```
 
@@ -115,7 +130,7 @@ QString extracted = JlCompress::extractFile("archive.zip", "document.txt", "outp
 
 ## QuaCompress API
 
-Use for readable, fluent chaining of operations with sensible defaults.
+Use for readable, fluent chaining of operations.
 
 ### Compress
 
@@ -153,10 +168,6 @@ QStringList files = QuaCompress()
 files = QuaCompress()
     .withPassword(QByteArray("password123"))
     .extractDir("archive.zip", "output_dir");
-
-// Or pass password as parameter
-files = QuaCompress()
-    .extractDir("archive.zip", "output_dir", QByteArray("password123"));
 
 // Get file list
 QStringList fileNames = QuaCompress()

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -128,9 +128,9 @@ QStringList extracted = JlCompress::extractDir("archive.zip", "output_dir");
 QString extracted = JlCompress::extractFile("archive.zip", "document.txt", "output.txt", QByteArray("password123"));
 ```
 
-## QuaCompress API
+## Fluent API (QuaCompress/QuaExtract)
 
-Use for readable, fluent chaining of operations.
+Use for readable, type-safe fluent chaining of operations. Separate classes prevent accidentally mixing compression and extraction options.
 
 ### Compress
 
@@ -143,34 +143,43 @@ bool ok = QuaCompress()
 
 // Chain multiple options
 ok = QuaCompress()
-    .withUtf8Enabled(true)
-    .withCompression(JlCompress::Options::Best)
+    .withUtf8Enabled()
+    .withStrategy(QuaCompress::Best)
     .withPassword(QByteArray("password123"))
     .compressFile("archive.zip", "document.txt");
 
-// Compress directory with options
+// Compress directory with custom filters
 ok = QuaCompress()
-    .withUtf8Enabled(true)
-    .withCompression(JlCompress::Options::Better)
-    .compressDir("archive.zip", "my_folder", true);
+    .withUtf8Enabled()
+    .withStrategy(QuaCompress::Better)
+    .compressDir("archive.zip", "my_folder", true, QDir::Files | QDir::NoDotAndDotDot);
+
+// Add files to existing archive
+ok = QuaCompress()
+    .withUtf8Enabled()
+    .addFile("archive.zip", "new_file.txt");
 ```
 
 ### Extract
 
 ```cpp
-#include <QuaCompress.h>
+#include <QuaExtract.h>
 
 // Simple extraction
-QStringList files = QuaCompress()
+QStringList files = QuaExtract()
     .extractDir("archive.zip", "output_dir");
 
-// Extract with password using fluent API
-files = QuaCompress()
+// Extract with password
+files = QuaExtract()
     .withPassword(QByteArray("password123"))
     .extractDir("archive.zip", "output_dir");
 
+// Extract a single file
+QString extracted = QuaExtract()
+    .extractFile("archive.zip", "document.txt", "output.txt");
+
 // Get file list
-QStringList fileNames = QuaCompress()
+QStringList fileNames = QuaExtract()
     .getFileList("archive.zip");
 ```
 
@@ -178,6 +187,6 @@ QStringList fileNames = QuaCompress()
 
 - **Low-Level API**: Use when you need streaming I/O, custom error handling, or per-file control.
 - **JlCompress**: Use for simple, one-line operations; static utility pattern.
-- **QuaCompress**: Use when you want readable code with method chaining and discoverable options.
+- **QuaCompress/QuaExtract**: Similar to JlCompress but with fluent API.
 
-All three APIs support UTF-8 filenames, password encryption, and multiple compression levels. JlCompress and QuaCompress provide built-in path traversal protection when extracting archives.
+All three APIs support UTF-8 filenames, password encryption, and multiple compression levels. JlCompress and the fluent API provide built-in path traversal protection when extracting archives.

--- a/README.md
+++ b/README.md
@@ -115,3 +115,7 @@ CMake options
 | `QUAZIP_BZIP2_STDIO`        | Output BZIP2 errors to stdio when BZIP2 compression is enabled                                                                                                | `ON`    |
 | `QUAZIP_ENABLE_QTEXTCODEC`  | Set to OFF to explicitely disable the use of QTextCodec on Qt6 even if Core5Compat is available. This uses [QStringConverter](https://doc.qt.io/qt-6/qstringconverter.html) in the background with less supported encodings. | `ON`    |
 
+# Usage
+
+See [EXAMPLES.md](EXAMPLES.md) for code examples showing how to use QuaZip's three API levels: low-level QuaZip/QuaZipFile, JlCompress utility functions, and QuaCompress fluent interface.
+

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ See [EXAMPLES.md](EXAMPLES.md) for code examples showing how to use QuaZip's thr
 
 # UTF-8 Handling
 
-QuaZip supports setting the UTF-8 flag (bit 11) in ZIP file headers via `JlCompress::Options::setUtf8Enabled()` or `QuaZip::setUtf8Enabled()`. This flag tells extractors that filenames are UTF-8 encoded.
+QuaZip supports setting the UTF-8 flag ZIP file via `JlCompress::Options::setUtf8Enabled()` or `QuaZip::setUtf8Enabled()`. This flag tells extractors that filenames are UTF-8 encoded.
 
 ## Behavior Summary
 

--- a/README.md
+++ b/README.md
@@ -121,18 +121,14 @@ See [EXAMPLES.md](EXAMPLES.md) for code examples showing how to use QuaZip's thr
 
 # UTF-8 Handling
 
-The UTF-8 flag sets a bit in the ZIP file.
+QuaZip supports setting the UTF-8 flag (bit 11) in ZIP file headers via `JlCompress::Options::setUtf8Enabled()` or `QuaZip::setUtf8Enabled()`. This flag tells extractors that filenames are UTF-8 encoded.
 
-## Platform Behavior Without UTF-8 Flag
+## Behavior Summary
 
-If you don't set the flag and try to decompress such an archive, the behavior depends on the platform and default system encoding.  
-If your platform defaults to UTF-8 everything will just work.  
-If it doesn't, you can expect the following behavior:
-
-| Platform | Qt Version | Behavior | Example: `файл.txt` |
-|----------|-----------|----------|---------------------|
-| **Windows** | Any | Character replacement with `?` | `????.txt` |
-| **Linux** | Qt 5 | Character dropping (null truncation) | `.txt` |
-| **Linux** | Qt 6 | UTF-8 forced (preserved) | `файл.txt` |
-
-This is what was observed in QuaZip but other unzip tools might behave differently.
+| Platform | Qt Version | UTF-8 Flag | Locale | Result                             | Example: `файл.txt` |
+|----------|-----------|-----------|--------|------------------------------------|---------------------|
+| **Windows** | Any | ✓ Set | Any | ✓ Works                            | `файл.txt` |
+| **Windows** | Any | ✗ Not set | Any | ✗ Mangled (double-encoding or ???) | `Ñ„Ð°Ð¹Ð».txt` |
+| **Linux** | Qt 6 | Any | Any | ✓ Works (Qt forces UTF-8)          | `файл.txt` |
+| **Linux** | Qt 5 | Any | UTF-8 | ✓ Works                            | `файл.txt` |
+| **Linux** | Qt 5 | Any | non-UTF-8 | ✗ Truncated at null bytes          | `.txt` |

--- a/README.md
+++ b/README.md
@@ -119,3 +119,20 @@ CMake options
 
 See [EXAMPLES.md](EXAMPLES.md) for code examples showing how to use QuaZip's three API levels: low-level QuaZip/QuaZipFile, JlCompress utility functions, and QuaCompress fluent interface.
 
+# UTF-8 Handling
+
+The UTF-8 flag sets a bit in the ZIP file.
+
+## Platform Behavior Without UTF-8 Flag
+
+If you don't set the flag and try to decompress such an archive, the behavior depends on the platform and default system encoding.  
+If your platform defaults to UTF-8 everything will just work.  
+If it doesn't, you can expect the following behavior:
+
+| Platform | Qt Version | Behavior | Example: `файл.txt` |
+|----------|-----------|----------|---------------------|
+| **Windows** | Any | Character replacement with `?` | `????.txt` |
+| **Linux** | Qt 5 | Character dropping (null truncation) | `.txt` |
+| **Linux** | Qt 6 | UTF-8 forced (preserved) | `файл.txt` |
+
+This is what was observed in QuaZip but other unzip tools might behave differently.

--- a/quazip/CMakeLists.txt
+++ b/quazip/CMakeLists.txt
@@ -6,6 +6,7 @@ cmake_minimum_required(VERSION 3.13)
 
 set(QUAZIP_HEADERS
         JlCompress.h
+        QuaCompress.h
         ioapi.h
         minizip_crypt.h
         quaadler32.h
@@ -30,6 +31,7 @@ set(QUAZIP_SOURCES
         unzip.c
         zip.c
         JlCompress.cpp
+        QuaCompress.cpp
         qioapi.cpp
         quaadler32.cpp
         quachecksum32.cpp

--- a/quazip/CMakeLists.txt
+++ b/quazip/CMakeLists.txt
@@ -7,6 +7,7 @@ cmake_minimum_required(VERSION 3.13)
 set(QUAZIP_HEADERS
         JlCompress.h
         QuaCompress.h
+        QuaExtract.h
         ioapi.h
         minizip_crypt.h
         quaadler32.h
@@ -32,6 +33,7 @@ set(QUAZIP_SOURCES
         zip.c
         JlCompress.cpp
         QuaCompress.cpp
+        QuaExtract.cpp
         qioapi.cpp
         quaadler32.cpp
         quachecksum32.cpp

--- a/quazip/JlCompress.cpp
+++ b/quazip/JlCompress.cpp
@@ -98,6 +98,8 @@ bool JlCompress::compressSubDir(QuaZip* zip, QString dir, QString origDir, bool 
         zip->getMode()!=QuaZip::mdAppend &&
         zip->getMode()!=QuaZip::mdAdd) return false;
 
+    zip->setUtf8Enabled(options.getUtf8Enabled());
+
     QDir directory(dir);
     if (!directory.exists()) return false;
 
@@ -230,6 +232,8 @@ bool JlCompress::compressFile(QString fileCompressed, QString file) {
 bool JlCompress::compressFile(QString fileCompressed, QString file, const Options& options) {
     // Create zip
     QuaZip zip(fileCompressed);
+    zip.setUtf8Enabled(options.getUtf8Enabled());
+
     QDir().mkpath(QFileInfo(fileCompressed).absolutePath());
     if(!zip.open(QuaZip::mdCreate)) {
         QFile::remove(fileCompressed);
@@ -259,6 +263,7 @@ bool JlCompress::compressFiles(QString fileCompressed, QStringList files) {
 bool JlCompress::compressFiles(QString fileCompressed, QStringList files, const Options& options) {
   // Create zip
   QuaZip zip(fileCompressed);
+  zip.setUtf8Enabled(options.getUtf8Enabled());
   QDir().mkpath(QFileInfo(fileCompressed).absolutePath());
   if(!zip.open(QuaZip::mdCreate)) {
     QFile::remove(fileCompressed);
@@ -301,6 +306,7 @@ bool JlCompress::compressDir(QString fileCompressed, QString dir,
 {
   // Create zip
   QuaZip zip(fileCompressed);
+  zip.setUtf8Enabled(options.getUtf8Enabled());
   QDir().mkpath(QFileInfo(fileCompressed).absolutePath());
   if(!zip.open(QuaZip::mdCreate)) {
     QFile::remove(fileCompressed);

--- a/quazip/JlCompress.cpp
+++ b/quazip/JlCompress.cpp
@@ -98,8 +98,6 @@ bool JlCompress::compressSubDir(QuaZip* zip, QString dir, QString origDir, bool 
         zip->getMode()!=QuaZip::mdAppend &&
         zip->getMode()!=QuaZip::mdAdd) return false;
 
-    zip->setUtf8Enabled(options.getUtf8Enabled());
-
     QDir directory(dir);
     if (!directory.exists()) return false;
 
@@ -264,6 +262,7 @@ bool JlCompress::compressFiles(QString fileCompressed, QStringList files, const 
   // Create zip
   QuaZip zip(fileCompressed);
   zip.setUtf8Enabled(options.getUtf8Enabled());
+  
   QDir().mkpath(QFileInfo(fileCompressed).absolutePath());
   if(!zip.open(QuaZip::mdCreate)) {
     QFile::remove(fileCompressed);

--- a/quazip/JlCompress.cpp
+++ b/quazip/JlCompress.cpp
@@ -226,11 +226,6 @@ static std::pair<bool, bool> extractFileInternal(QuaZip* zip, QString fileName, 
     return {true, false};
 }
 
-// Overload without password - delegates to version with password
-static std::pair<bool, bool> extractFileInternal(QuaZip* zip, QString fileName, QString fileDest, const QString& baseDir = QString()) {
-    return extractFileInternal(zip, fileName, fileDest, QByteArray(), baseDir);
-}
-
 bool JlCompress::removeFile(QStringList listFile) {
     bool ret = true;
     // For each file
@@ -424,12 +419,7 @@ bool JlCompress::addDir(QString fileCompressed, QString dir,
   return zip.getZipError() == 0;
 }
 
-QString JlCompress::extractFile(QString fileCompressed, QString fileName, QString fileDest) {
-    // Delegate to password-enabled version with empty password
-    return extractFile(fileCompressed, fileName, fileDest, QByteArray());
-}
-
-QString JlCompress::extractFile(QuaZip &zip, QString fileName, QString fileDest)
+static QString extractFileSingleInternal(QuaZip &zip, QString fileName, QString fileDest, const QByteArray& password = QByteArray())
 {
     if(!zip.open(QuaZip::mdUnzip)) {
         return QString();
@@ -438,7 +428,7 @@ QString JlCompress::extractFile(QuaZip &zip, QString fileName, QString fileDest)
     // Extract file
     if (fileDest.isEmpty())
         fileDest = fileName;
-    std::pair<bool, bool> result = extractFileInternal(&zip, fileName, fileDest);
+    std::pair<bool, bool> result = extractFileInternal(&zip, fileName, fileDest, password);
     if (!result.first) {
         return QString();
     }
@@ -446,10 +436,20 @@ QString JlCompress::extractFile(QuaZip &zip, QString fileName, QString fileDest)
     // Close zip
     zip.close();
     if(zip.getZipError()!=0) {
-        removeFile(QStringList(fileDest));
+        JlCompress::removeFile(QStringList(fileDest));
         return QString();
     }
     return QFileInfo(fileDest).absoluteFilePath();
+}
+
+QString JlCompress::extractFile(QString fileCompressed, QString fileName, QString fileDest) {
+    // Delegate to password-enabled version with empty password
+    return extractFile(fileCompressed, fileName, fileDest, QByteArray());
+}
+
+QString JlCompress::extractFile(QuaZip &zip, QString fileName, QString fileDest)
+{
+    return extractFileSingleInternal(zip, fileName, fileDest);
 }
 
 QStringList JlCompress::extractFiles(QString fileCompressed, QStringList files, QString dir) {
@@ -457,7 +457,8 @@ QStringList JlCompress::extractFiles(QString fileCompressed, QStringList files, 
     return extractFiles(fileCompressed, files, dir, QByteArray());
 }
 
-QStringList JlCompress::extractFiles(QuaZip &zip, const QStringList &files, const QString &dir)
+// Internal helper that extracts specific files from an already-constructed QuaZip object
+static QStringList extractFilesInternal(QuaZip& zip, const QStringList& files, const QString& dir, const QByteArray& password = QByteArray())
 {
     if(!zip.open(QuaZip::mdUnzip)) {
         return QStringList();
@@ -468,13 +469,13 @@ QStringList JlCompress::extractFiles(QuaZip &zip, const QStringList &files, cons
     QDir directory(cleanDir);
     QString absCleanDir = directory.absolutePath();
 
-    // Extract file
     QStringList extracted;
     for (int i=0; i<files.count(); i++) {
         QString absPath = QDir(dir).absoluteFilePath(files.at(i));
-        std::pair<bool, bool> result = extractFileInternal(&zip, files.at(i), absPath, absCleanDir);
+        std::pair<bool, bool> result = extractFileInternal(&zip, files.at(i), absPath, password, absCleanDir);
         if (!result.first) {
-            removeFile(extracted);
+            JlCompress::removeFile(extracted);
+            zip.close();
             return QStringList();
         }
         if (!result.second) {
@@ -482,14 +483,18 @@ QStringList JlCompress::extractFiles(QuaZip &zip, const QStringList &files, cons
         }
     }
 
-    // Close zip
     zip.close();
     if(zip.getZipError()!=0) {
-        removeFile(extracted);
+        JlCompress::removeFile(extracted);
         return QStringList();
     }
 
     return extracted;
+}
+
+QStringList JlCompress::extractFiles(QuaZip &zip, const QStringList &files, const QString &dir)
+{
+    return extractFilesInternal(zip, files, dir);
 }
 
 QStringList JlCompress::extractDir(QString fileCompressed, QuazipTextCodec* fileNameCodec, QString dir) {
@@ -505,7 +510,8 @@ QStringList JlCompress::extractDir(QString fileCompressed, QString dir) {
     return extractDir(fileCompressed, dir, QByteArray());
 }
 
-QStringList JlCompress::extractDir(QuaZip &zip, const QString &dir)
+// Internal helper that extracts all files from an already-constructed QuaZip object
+static QStringList extractDirInternal(QuaZip& zip, const QString& dir, const QByteArray& password = QByteArray())
 {
     if(!zip.open(QuaZip::mdUnzip)) {
         return QStringList();
@@ -515,15 +521,17 @@ QStringList JlCompress::extractDir(QuaZip &zip, const QString &dir)
     QString absCleanDir = directory.absolutePath();
     QStringList extracted;
     if (!zip.goToFirstFile()) {
+        zip.close();
         return QStringList();
     }
     do {
         QString name = zip.getCurrentFileName();
         QString absFilePath = directory.absoluteFilePath(name);
         // Path traversal validation is done inside extractFile
-        std::pair<bool, bool> result = extractFileInternal(&zip, QLatin1String(""), absFilePath, absCleanDir);
+        std::pair<bool, bool> result = extractFileInternal(&zip, QLatin1String(""), absFilePath, password, absCleanDir);
         if (!result.first) {
-            removeFile(extracted);
+            JlCompress::removeFile(extracted);
+            zip.close();
             return QStringList();
         }
         if (!result.second) {
@@ -531,14 +539,18 @@ QStringList JlCompress::extractDir(QuaZip &zip, const QString &dir)
         }
     } while (zip.goToNextFile());
 
-    // Close zip
     zip.close();
     if(zip.getZipError()!=0) {
-        removeFile(extracted);
+        JlCompress::removeFile(extracted);
         return QStringList();
     }
 
     return extracted;
+}
+
+QStringList JlCompress::extractDir(QuaZip &zip, const QString &dir)
+{
+    return extractDirInternal(zip, dir);
 }
 
 QStringList JlCompress::getFileList(QString fileCompressed) {
@@ -610,83 +622,15 @@ QStringList JlCompress::extractFiles(QIODevice *ioDevice, QStringList files, QSt
 // Extract with password support
 QString JlCompress::extractFile(QString fileCompressed, QString fileName, QString fileDest, const QByteArray& password) {
     QuaZip zip(fileCompressed);
-    if(!zip.open(QuaZip::mdUnzip)) {
-        return QString();
-    }
-    if (fileDest.isEmpty())
-        fileDest = fileName;
-    std::pair<bool, bool> result = extractFileInternal(&zip, fileName, fileDest, password);
-    if (!result.first) {
-        return QString();
-    }
-    zip.close();
-    if(zip.getZipError()!=0) {
-        removeFile(QStringList(fileDest));
-        return QString();
-    }
-    return QFileInfo(fileDest).absoluteFilePath();
+    return extractFileSingleInternal(zip, fileName, fileDest, password);
 }
 
 QStringList JlCompress::extractFiles(QString fileCompressed, QStringList files, QString dir, const QByteArray& password) {
     QuaZip zip(fileCompressed);
-    if(!zip.open(QuaZip::mdUnzip)) {
-        return QStringList();
-    }
-
-    // Prepare base directory for path traversal protection
-    QString cleanDir = QDir::cleanPath(dir);
-    QDir directory(cleanDir);
-    QString absCleanDir = directory.absolutePath();
-
-    QStringList extracted;
-    for (int i=0; i<files.count(); i++) {
-        QString absPath = QDir(dir).absoluteFilePath(files.at(i));
-        std::pair<bool, bool> result = extractFileInternal(&zip, files.at(i), absPath, password, absCleanDir);
-        if (!result.first) {
-            removeFile(extracted);
-            return QStringList();
-        }
-        if (!result.second) {
-            extracted.append(absPath);
-        }
-    }
-    zip.close();
-    if(zip.getZipError()!=0) {
-        removeFile(extracted);
-        return QStringList();
-    }
-    return extracted;
+    return extractFilesInternal(zip, files, dir, password);
 }
 
 QStringList JlCompress::extractDir(QString fileCompressed, QString dir, const QByteArray& password) {
     QuaZip zip(fileCompressed);
-    if(!zip.open(QuaZip::mdUnzip)) {
-        return QStringList();
-    }
-    QString cleanDir = QDir::cleanPath(dir);
-    QDir directory(cleanDir);
-    QString absCleanDir = directory.absolutePath();
-    QStringList extracted;
-    if (!zip.goToFirstFile()) {
-        return QStringList();
-    }
-    do {
-        QString name = zip.getCurrentFileName();
-        QString absFilePath = directory.absoluteFilePath(name);
-        // Path traversal validation is done inside extractFile
-        std::pair<bool, bool> result = extractFileInternal(&zip, "", absFilePath, password, absCleanDir);
-        if (!result.first) {
-            removeFile(extracted);
-            return QStringList();
-        }
-        if (!result.second) {
-            extracted.append(absFilePath);
-        }
-    } while (zip.goToNextFile());
-    zip.close();
-    if(zip.getZipError()!=0) {
-        removeFile(extracted);
-        return QStringList();
-    }
-    return extracted;
+    return extractDirInternal(zip, dir, password);
 }

--- a/quazip/JlCompress.cpp
+++ b/quazip/JlCompress.cpp
@@ -452,6 +452,13 @@ QString JlCompress::extractFile(QuaZip &zip, QString fileName, QString fileDest)
     return extractFileSingleInternal(zip, fileName, fileDest);
 }
 
+bool JlCompress::extractFile(QuaZip* zip, QString fileName, QString fileDest)
+{
+    if (!zip) return false;
+    std::pair<bool, bool> result = extractFileInternal(zip, fileName, fileDest, QByteArray());
+    return result.first;
+}
+
 QStringList JlCompress::extractFiles(QString fileCompressed, QStringList files, QString dir) {
     // Delegate to password-enabled version with empty password
     return extractFiles(fileCompressed, files, dir, QByteArray());

--- a/quazip/JlCompress.cpp
+++ b/quazip/JlCompress.cpp
@@ -147,12 +147,9 @@ bool JlCompress::compressSubDir(QuaZip* zip, QString dir, QString origDir, bool 
     return true;
 }
 
-std::pair<bool, bool> JlCompress::extractFile(QuaZip* zip, QString fileName, QString fileDest, const QString& baseDir) {
-    // Delegate to password-enabled version with empty password
-    return extractFile(zip, fileName, fileDest, QByteArray(), baseDir);
-}
-
-std::pair<bool, bool> JlCompress::extractFile(QuaZip* zip, QString fileName, QString fileDest, const QByteArray& password, const QString& baseDir) {
+// Internal helper for extraction with password and path traversal protection
+// Second bool is true if entry was skipped due to traversal protection
+static std::pair<bool, bool> extractFileInternal(QuaZip* zip, QString fileName, QString fileDest, const QByteArray& password, const QString& baseDir = QString()) {
     if (!zip) return {false, false};
     if (zip->getMode()!=QuaZip::mdUnzip) return {false, false};
 
@@ -210,16 +207,16 @@ std::pair<bool, bool> JlCompress::extractFile(QuaZip* zip, QString fileName, QSt
     outFile.setFileName(fileDest);
     if(!outFile.open(QIODevice::WriteOnly)) return {false, false};
 
-    if (!copyData(inFile, outFile) || inFile.getZipError()!=UNZ_OK) {
+    if (!JlCompress::copyData(inFile, outFile) || inFile.getZipError()!=UNZ_OK) {
         outFile.close();
-        removeFile(QStringList(fileDest));
+        JlCompress::removeFile(QStringList(fileDest));
         return {false, false};
     }
     outFile.close();
 
     inFile.close();
     if (inFile.getZipError()!=UNZ_OK) {
-        removeFile(QStringList(fileDest));
+        JlCompress::removeFile(QStringList(fileDest));
         return {false, false};
     }
 
@@ -227,6 +224,11 @@ std::pair<bool, bool> JlCompress::extractFile(QuaZip* zip, QString fileName, QSt
         outFile.setPermissions(srcPerm);
     }
     return {true, false};
+}
+
+// Overload without password - delegates to version with password
+static std::pair<bool, bool> extractFileInternal(QuaZip* zip, QString fileName, QString fileDest, const QString& baseDir = QString()) {
+    return extractFileInternal(zip, fileName, fileDest, QByteArray(), baseDir);
 }
 
 bool JlCompress::removeFile(QStringList listFile) {
@@ -436,7 +438,7 @@ QString JlCompress::extractFile(QuaZip &zip, QString fileName, QString fileDest)
     // Extract file
     if (fileDest.isEmpty())
         fileDest = fileName;
-    std::pair<bool, bool> result = extractFile(&zip, fileName, fileDest);
+    std::pair<bool, bool> result = extractFileInternal(&zip, fileName, fileDest);
     if (!result.first) {
         return QString();
     }
@@ -470,7 +472,7 @@ QStringList JlCompress::extractFiles(QuaZip &zip, const QStringList &files, cons
     QStringList extracted;
     for (int i=0; i<files.count(); i++) {
         QString absPath = QDir(dir).absoluteFilePath(files.at(i));
-        std::pair<bool, bool> result = extractFile(&zip, files.at(i), absPath, absCleanDir);
+        std::pair<bool, bool> result = extractFileInternal(&zip, files.at(i), absPath, absCleanDir);
         if (!result.first) {
             removeFile(extracted);
             return QStringList();
@@ -519,7 +521,7 @@ QStringList JlCompress::extractDir(QuaZip &zip, const QString &dir)
         QString name = zip.getCurrentFileName();
         QString absFilePath = directory.absoluteFilePath(name);
         // Path traversal validation is done inside extractFile
-        std::pair<bool, bool> result = extractFile(&zip, QLatin1String(""), absFilePath, absCleanDir);
+        std::pair<bool, bool> result = extractFileInternal(&zip, QLatin1String(""), absFilePath, absCleanDir);
         if (!result.first) {
             removeFile(extracted);
             return QStringList();
@@ -613,7 +615,7 @@ QString JlCompress::extractFile(QString fileCompressed, QString fileName, QStrin
     }
     if (fileDest.isEmpty())
         fileDest = fileName;
-    std::pair<bool, bool> result = extractFile(&zip, fileName, fileDest, password);
+    std::pair<bool, bool> result = extractFileInternal(&zip, fileName, fileDest, password);
     if (!result.first) {
         return QString();
     }
@@ -639,7 +641,7 @@ QStringList JlCompress::extractFiles(QString fileCompressed, QStringList files, 
     QStringList extracted;
     for (int i=0; i<files.count(); i++) {
         QString absPath = QDir(dir).absoluteFilePath(files.at(i));
-        std::pair<bool, bool> result = extractFile(&zip, files.at(i), absPath, password, absCleanDir);
+        std::pair<bool, bool> result = extractFileInternal(&zip, files.at(i), absPath, password, absCleanDir);
         if (!result.first) {
             removeFile(extracted);
             return QStringList();
@@ -672,7 +674,7 @@ QStringList JlCompress::extractDir(QString fileCompressed, QString dir, const QB
         QString name = zip.getCurrentFileName();
         QString absFilePath = directory.absoluteFilePath(name);
         // Path traversal validation is done inside extractFile
-        std::pair<bool, bool> result = extractFile(&zip, "", absFilePath, password, absCleanDir);
+        std::pair<bool, bool> result = extractFileInternal(&zip, "", absFilePath, password, absCleanDir);
         if (!result.first) {
             removeFile(extracted);
             return QStringList();

--- a/quazip/JlCompress.cpp
+++ b/quazip/JlCompress.cpp
@@ -54,11 +54,12 @@ bool JlCompress::compressFile(QuaZip* zip, QString fileName, QString fileDest, c
         zip->getMode()!=QuaZip::mdAdd) return false;
 
     QuaZipFile outFile(zip);
+    const char *password = options.getPassword().isEmpty() ? nullptr : options.getPassword().constData();
     if (options.getDateTime().isNull()) {
-      if(!outFile.open(QIODevice::WriteOnly, QuaZipNewInfo(fileDest, fileName), nullptr, 0, options.getCompressionMethod(), options.getCompressionLevel())) return false;
+      if(!outFile.open(QIODevice::WriteOnly, QuaZipNewInfo(fileDest, fileName), password, 0, options.getCompressionMethod(), options.getCompressionLevel())) return false;
     }
     else {
-      if(!outFile.open(QIODevice::WriteOnly, QuaZipNewInfo(fileDest, fileName, options.getDateTime()), nullptr, 0, options.getCompressionMethod(), options.getCompressionLevel())) return false;
+      if(!outFile.open(QIODevice::WriteOnly, QuaZipNewInfo(fileDest, fileName, options.getDateTime()), password, 0, options.getCompressionMethod(), options.getCompressionLevel())) return false;
     }
 
     QFileInfo input(fileName);
@@ -104,6 +105,7 @@ bool JlCompress::compressSubDir(QuaZip* zip, QString dir, QString origDir, bool 
     QDir origDirectory(origDir);
     if (dir != origDir) {
         QuaZipFile dirZipFile(zip);
+        const char *password = options.getPassword().isEmpty() ? nullptr : options.getPassword().constData();
         std::unique_ptr<QuaZipNewInfo> qzni;
         if (options.getDateTime().isNull()) {
             qzni = std::make_unique<QuaZipNewInfo>(origDirectory.relativeFilePath(dir) + QLatin1String("/"), dir);
@@ -111,7 +113,7 @@ bool JlCompress::compressSubDir(QuaZip* zip, QString dir, QString origDir, bool 
         else {
             qzni = std::make_unique<QuaZipNewInfo>(origDirectory.relativeFilePath(dir) + QLatin1String("/"), dir, options.getDateTime());
         }
-        if (!dirZipFile.open(QIODevice::WriteOnly, *qzni, nullptr, 0, 0)) {
+        if (!dirZipFile.open(QIODevice::WriteOnly, *qzni, password, 0, 0)) {
             return false;
         }
         dirZipFile.close();
@@ -145,72 +147,86 @@ bool JlCompress::compressSubDir(QuaZip* zip, QString dir, QString origDir, bool 
     return true;
 }
 
-bool JlCompress::extractFile(QuaZip* zip, QString fileName, QString fileDest) {
-    // zip: object where to add the file
-    // filename: real file name
-    // fileincompress: file name of the compressed file
+std::pair<bool, bool> JlCompress::extractFile(QuaZip* zip, QString fileName, QString fileDest, const QString& baseDir) {
+    // Delegate to password-enabled version with empty password
+    return extractFile(zip, fileName, fileDest, QByteArray(), baseDir);
+}
 
-    if (!zip) return false;
-    if (zip->getMode()!=QuaZip::mdUnzip) return false;
+std::pair<bool, bool> JlCompress::extractFile(QuaZip* zip, QString fileName, QString fileDest, const QByteArray& password, const QString& baseDir) {
+    if (!zip) return {false, false};
+    if (zip->getMode()!=QuaZip::mdUnzip) return {false, false};
+
+    // Path traversal protection: validate fileDest is within baseDir if baseDir is provided
+    if (!baseDir.isEmpty()) {
+        QString cleanBase = QDir::cleanPath(baseDir);
+        QDir directory(cleanBase);
+        QString absCleanBase = directory.absolutePath();
+        if (!absCleanBase.endsWith(QLatin1Char('/')))
+            absCleanBase += QLatin1Char('/');
+
+        QString absCleanPath = QDir::cleanPath(QFileInfo(fileDest).absoluteFilePath());
+        if (!absCleanPath.startsWith(absCleanBase)) {
+            return {true, true}; // success=true, wasSkipped=true (skip path traversal attempt)
+        }
+    }
 
     if (!fileName.isEmpty())
         zip->setCurrentFile(fileName);
     QuaZipFile inFile(zip);
-    if(!inFile.open(QIODevice::ReadOnly) || inFile.getZipError()!=UNZ_OK) return false;
+    // Convert QByteArray to const char* for QuaZipFile API
+    const char *pwd = password.isEmpty() ? nullptr : password.constData();
+    if(!inFile.open(QIODevice::ReadOnly, pwd) || inFile.getZipError()!=UNZ_OK) return {false, false};
 
     // Check existence of resulting file
     QDir curDir;
     if (fileDest.endsWith(QLatin1String("/"))) {
         if (!curDir.mkpath(fileDest)) {
-            return false;
+            return {false, false};
         }
     } else {
         if (!curDir.mkpath(QFileInfo(fileDest).absolutePath())) {
-            return false;
+            return {false, false};
         }
     }
 
     QuaZipFileInfo64 info;
     if (!zip->getCurrentFileInfo(&info))
-        return false;
+        return {false, false};
 
     QFile::Permissions srcPerm = info.getPermissions();
     if (fileDest.endsWith(QLatin1String("/")) && QFileInfo(fileDest).isDir()) {
         if (srcPerm != 0) {
             QFile(fileDest).setPermissions(srcPerm);
         }
-        return true;
+        return {true, false};
     }
 
     if (info.isSymbolicLink()) {
         QString target = QFile::decodeName(inFile.readAll());
-        return QFile::link(target, fileDest);
+        return {QFile::link(target, fileDest), false};
     }
 
-    // Open resulting file
     QFile outFile;
     outFile.setFileName(fileDest);
-    if(!outFile.open(QIODevice::WriteOnly)) return false;
+    if(!outFile.open(QIODevice::WriteOnly)) return {false, false};
 
-    // Copy data
     if (!copyData(inFile, outFile) || inFile.getZipError()!=UNZ_OK) {
         outFile.close();
         removeFile(QStringList(fileDest));
-        return false;
+        return {false, false};
     }
     outFile.close();
 
-    // Close file
     inFile.close();
     if (inFile.getZipError()!=UNZ_OK) {
         removeFile(QStringList(fileDest));
-        return false;
+        return {false, false};
     }
 
     if (srcPerm != 0) {
         outFile.setPermissions(srcPerm);
     }
-    return true;
+    return {true, false};
 }
 
 bool JlCompress::removeFile(QStringList listFile) {
@@ -231,9 +247,6 @@ bool JlCompress::compressFile(QString fileCompressed, QString file, const Option
     // Create zip
     QuaZip zip(fileCompressed);
     zip.setUtf8Enabled(options.getUtf8Enabled());
-    if (fileCompressed=="jlsimplefile-utf8-bad.zip") {
-      zip.setFileNameCodec(QTextCodec::codecForName("Windows-1250"));
-    }
 
     QDir().mkpath(QFileInfo(fileCompressed).absolutePath());
     if(!zip.open(QuaZip::mdCreate)) {
@@ -352,6 +365,8 @@ bool JlCompress::addFiles(QString fileCompressed, QStringList files, const Optio
 
   // Open existing zip
   QuaZip zip(fileCompressed);
+  // Set UTF-8 flag before opening. Must match the existing archive's encoding.
+  zip.setUtf8Enabled(options.getUtf8Enabled());
   if(!zip.open(QuaZip::mdAdd)) {
     return false;
   }
@@ -390,6 +405,8 @@ bool JlCompress::addDir(QString fileCompressed, QString dir,
 
   // Open existing zip
   QuaZip zip(fileCompressed);
+  // Set UTF-8 flag before opening. Must match the existing archive's encoding.
+  zip.setUtf8Enabled(options.getUtf8Enabled());
   if(!zip.open(QuaZip::mdAdd)) {
     return false;
   }
@@ -406,9 +423,8 @@ bool JlCompress::addDir(QString fileCompressed, QString dir,
 }
 
 QString JlCompress::extractFile(QString fileCompressed, QString fileName, QString fileDest) {
-    // Open zip
-    QuaZip zip(fileCompressed);
-    return extractFile(zip, fileName, fileDest);
+    // Delegate to password-enabled version with empty password
+    return extractFile(fileCompressed, fileName, fileDest, QByteArray());
 }
 
 QString JlCompress::extractFile(QuaZip &zip, QString fileName, QString fileDest)
@@ -420,7 +436,8 @@ QString JlCompress::extractFile(QuaZip &zip, QString fileName, QString fileDest)
     // Extract file
     if (fileDest.isEmpty())
         fileDest = fileName;
-    if (!extractFile(&zip,fileName,fileDest)) {
+    auto [success, skipped] = extractFile(&zip, fileName, fileDest);
+    if (!success) {
         return QString();
     }
 
@@ -434,9 +451,8 @@ QString JlCompress::extractFile(QuaZip &zip, QString fileName, QString fileDest)
 }
 
 QStringList JlCompress::extractFiles(QString fileCompressed, QStringList files, QString dir) {
-    // Create zip
-    QuaZip zip(fileCompressed);
-    return extractFiles(zip, files, dir);
+    // Delegate to password-enabled version with empty password
+    return extractFiles(fileCompressed, files, dir, QByteArray());
 }
 
 QStringList JlCompress::extractFiles(QuaZip &zip, const QStringList &files, const QString &dir)
@@ -445,15 +461,23 @@ QStringList JlCompress::extractFiles(QuaZip &zip, const QStringList &files, cons
         return QStringList();
     }
 
+    // Prepare base directory for path traversal protection
+    QString cleanDir = QDir::cleanPath(dir);
+    QDir directory(cleanDir);
+    QString absCleanDir = directory.absolutePath();
+
     // Extract file
     QStringList extracted;
     for (int i=0; i<files.count(); i++) {
         QString absPath = QDir(dir).absoluteFilePath(files.at(i));
-        if (!extractFile(&zip, files.at(i), absPath)) {
+        auto [success, skipped] = extractFile(&zip, files.at(i), absPath, absCleanDir);
+        if (!success) {
             removeFile(extracted);
             return QStringList();
         }
-        extracted.append(absPath);
+        if (!skipped) {
+            extracted.append(absPath);
+        }
     }
 
     // Close zip
@@ -475,7 +499,8 @@ QStringList JlCompress::extractDir(QString fileCompressed, QuazipTextCodec* file
 }
 
 QStringList JlCompress::extractDir(QString fileCompressed, QString dir) {
-    return extractDir(fileCompressed, nullptr, dir);
+    // Delegate to password-enabled version with empty password
+    return extractDir(fileCompressed, dir, QByteArray());
 }
 
 QStringList JlCompress::extractDir(QuaZip &zip, const QString &dir)
@@ -486,8 +511,6 @@ QStringList JlCompress::extractDir(QuaZip &zip, const QString &dir)
     QString cleanDir = QDir::cleanPath(dir);
     QDir directory(cleanDir);
     QString absCleanDir = directory.absolutePath();
-    if (!absCleanDir.endsWith(QLatin1Char('/'))) // It only ends with / if it's the FS root.
-        absCleanDir += QLatin1Char('/');
     QStringList extracted;
     if (!zip.goToFirstFile()) {
         return QStringList();
@@ -495,14 +518,15 @@ QStringList JlCompress::extractDir(QuaZip &zip, const QString &dir)
     do {
         QString name = zip.getCurrentFileName();
         QString absFilePath = directory.absoluteFilePath(name);
-        QString absCleanPath = QDir::cleanPath(absFilePath);
-        if (!absCleanPath.startsWith(absCleanDir))
-            continue;
-        if (!extractFile(&zip, QLatin1String(""), absFilePath)) {
+        // Path traversal validation is done inside extractFile
+        auto [success, skipped] = extractFile(&zip, QLatin1String(""), absFilePath, absCleanDir);
+        if (!success) {
             removeFile(extracted);
             return QStringList();
         }
-        extracted.append(absFilePath);
+        if (!skipped) {
+            extracted.append(absFilePath);
+        }
     } while (zip.goToNextFile());
 
     // Close zip
@@ -580,3 +604,87 @@ QStringList JlCompress::extractFiles(QIODevice *ioDevice, QStringList files, QSt
     QuaZip zip(ioDevice);
     return extractFiles(zip, files, dir);
 } 
+
+// Extract with password support
+QString JlCompress::extractFile(QString fileCompressed, QString fileName, QString fileDest, const QByteArray& password) {
+    QuaZip zip(fileCompressed);
+    if(!zip.open(QuaZip::mdUnzip)) {
+        return QString();
+    }
+    if (fileDest.isEmpty())
+        fileDest = fileName;
+    auto [success, skipped] = extractFile(&zip, fileName, fileDest, password);
+    if (!success) {
+        return QString();
+    }
+    zip.close();
+    if(zip.getZipError()!=0) {
+        removeFile(QStringList(fileDest));
+        return QString();
+    }
+    return QFileInfo(fileDest).absoluteFilePath();
+}
+
+QStringList JlCompress::extractFiles(QString fileCompressed, QStringList files, QString dir, const QByteArray& password) {
+    QuaZip zip(fileCompressed);
+    if(!zip.open(QuaZip::mdUnzip)) {
+        return QStringList();
+    }
+
+    // Prepare base directory for path traversal protection
+    QString cleanDir = QDir::cleanPath(dir);
+    QDir directory(cleanDir);
+    QString absCleanDir = directory.absolutePath();
+
+    QStringList extracted;
+    for (int i=0; i<files.count(); i++) {
+        QString absPath = QDir(dir).absoluteFilePath(files.at(i));
+        auto [success, skipped] = extractFile(&zip, files.at(i), absPath, password, absCleanDir);
+        if (!success) {
+            removeFile(extracted);
+            return QStringList();
+        }
+        if (!skipped) {
+            extracted.append(absPath);
+        }
+    }
+    zip.close();
+    if(zip.getZipError()!=0) {
+        removeFile(extracted);
+        return QStringList();
+    }
+    return extracted;
+}
+
+QStringList JlCompress::extractDir(QString fileCompressed, QString dir, const QByteArray& password) {
+    QuaZip zip(fileCompressed);
+    if(!zip.open(QuaZip::mdUnzip)) {
+        return QStringList();
+    }
+    QString cleanDir = QDir::cleanPath(dir);
+    QDir directory(cleanDir);
+    QString absCleanDir = directory.absolutePath();
+    QStringList extracted;
+    if (!zip.goToFirstFile()) {
+        return QStringList();
+    }
+    do {
+        QString name = zip.getCurrentFileName();
+        QString absFilePath = directory.absoluteFilePath(name);
+        // Path traversal validation is done inside extractFile
+        auto [success, skipped] = extractFile(&zip, "", absFilePath, password, absCleanDir);
+        if (!success) {
+            removeFile(extracted);
+            return QStringList();
+        }
+        if (!skipped) {
+            extracted.append(absFilePath);
+        }
+    } while (zip.goToNextFile());
+    zip.close();
+    if(zip.getZipError()!=0) {
+        removeFile(extracted);
+        return QStringList();
+    }
+    return extracted;
+}

--- a/quazip/JlCompress.cpp
+++ b/quazip/JlCompress.cpp
@@ -231,6 +231,9 @@ bool JlCompress::compressFile(QString fileCompressed, QString file, const Option
     // Create zip
     QuaZip zip(fileCompressed);
     zip.setUtf8Enabled(options.getUtf8Enabled());
+    if (fileCompressed=="jlsimplefile-utf8-bad.zip") {
+      zip.setFileNameCodec(QTextCodec::codecForName("Windows-1250"));
+    }
 
     QDir().mkpath(QFileInfo(fileCompressed).absolutePath());
     if(!zip.open(QuaZip::mdCreate)) {
@@ -262,7 +265,7 @@ bool JlCompress::compressFiles(QString fileCompressed, QStringList files, const 
   // Create zip
   QuaZip zip(fileCompressed);
   zip.setUtf8Enabled(options.getUtf8Enabled());
-  
+
   QDir().mkpath(QFileInfo(fileCompressed).absolutePath());
   if(!zip.open(QuaZip::mdCreate)) {
     QFile::remove(fileCompressed);

--- a/quazip/JlCompress.cpp
+++ b/quazip/JlCompress.cpp
@@ -436,8 +436,8 @@ QString JlCompress::extractFile(QuaZip &zip, QString fileName, QString fileDest)
     // Extract file
     if (fileDest.isEmpty())
         fileDest = fileName;
-    auto [success, skipped] = extractFile(&zip, fileName, fileDest);
-    if (!success) {
+    std::pair<bool, bool> result = extractFile(&zip, fileName, fileDest);
+    if (!result.first) {
         return QString();
     }
 
@@ -470,12 +470,12 @@ QStringList JlCompress::extractFiles(QuaZip &zip, const QStringList &files, cons
     QStringList extracted;
     for (int i=0; i<files.count(); i++) {
         QString absPath = QDir(dir).absoluteFilePath(files.at(i));
-        auto [success, skipped] = extractFile(&zip, files.at(i), absPath, absCleanDir);
-        if (!success) {
+        std::pair<bool, bool> result = extractFile(&zip, files.at(i), absPath, absCleanDir);
+        if (!result.first) {
             removeFile(extracted);
             return QStringList();
         }
-        if (!skipped) {
+        if (!result.second) {
             extracted.append(absPath);
         }
     }
@@ -519,12 +519,12 @@ QStringList JlCompress::extractDir(QuaZip &zip, const QString &dir)
         QString name = zip.getCurrentFileName();
         QString absFilePath = directory.absoluteFilePath(name);
         // Path traversal validation is done inside extractFile
-        auto [success, skipped] = extractFile(&zip, QLatin1String(""), absFilePath, absCleanDir);
-        if (!success) {
+        std::pair<bool, bool> result = extractFile(&zip, QLatin1String(""), absFilePath, absCleanDir);
+        if (!result.first) {
             removeFile(extracted);
             return QStringList();
         }
-        if (!skipped) {
+        if (!result.second) {
             extracted.append(absFilePath);
         }
     } while (zip.goToNextFile());
@@ -613,8 +613,8 @@ QString JlCompress::extractFile(QString fileCompressed, QString fileName, QStrin
     }
     if (fileDest.isEmpty())
         fileDest = fileName;
-    auto [success, skipped] = extractFile(&zip, fileName, fileDest, password);
-    if (!success) {
+    std::pair<bool, bool> result = extractFile(&zip, fileName, fileDest, password);
+    if (!result.first) {
         return QString();
     }
     zip.close();
@@ -639,12 +639,12 @@ QStringList JlCompress::extractFiles(QString fileCompressed, QStringList files, 
     QStringList extracted;
     for (int i=0; i<files.count(); i++) {
         QString absPath = QDir(dir).absoluteFilePath(files.at(i));
-        auto [success, skipped] = extractFile(&zip, files.at(i), absPath, password, absCleanDir);
-        if (!success) {
+        std::pair<bool, bool> result = extractFile(&zip, files.at(i), absPath, password, absCleanDir);
+        if (!result.first) {
             removeFile(extracted);
             return QStringList();
         }
-        if (!skipped) {
+        if (!result.second) {
             extracted.append(absPath);
         }
     }
@@ -672,12 +672,12 @@ QStringList JlCompress::extractDir(QString fileCompressed, QString dir, const QB
         QString name = zip.getCurrentFileName();
         QString absFilePath = directory.absoluteFilePath(name);
         // Path traversal validation is done inside extractFile
-        auto [success, skipped] = extractFile(&zip, "", absFilePath, password, absCleanDir);
-        if (!success) {
+        std::pair<bool, bool> result = extractFile(&zip, "", absFilePath, password, absCleanDir);
+        if (!result.first) {
             removeFile(extracted);
             return QStringList();
         }
-        if (!skipped) {
+        if (!result.second) {
             extracted.append(absFilePath);
         }
     } while (zip.goToNextFile());

--- a/quazip/JlCompress.h
+++ b/quazip/JlCompress.h
@@ -212,23 +212,6 @@ public:
     static bool compressSubDir(QuaZip* parentZip, QString dir, QString parentDir, bool recursive,
                                QDir::Filters filters, const Options& options);
 
-    /// Extract a single file.
-    /**
-      \param zip The opened zip archive to extract from.
-      \param fileName The full name of the file to extract.
-      \param fileDest The full path to the destination file.
-      \param baseDir Base directory for path traversal validation (optional).
-      \param password Password for encrypted files (optional, second overload only).
-      \return std::pair<bool, bool> where:
-              - first: success status (true if extraction succeeded or file was safely skipped, false on error)
-              - second: wasSkipped status (true if file was skipped due to path traversal protection, false otherwise)
-
-      When path traversal is detected (file attempting to escape baseDir), the function returns {true, true}
-      to allow processing to continue while skipping the malicious file.
-      */
-    static std::pair<bool, bool> extractFile(QuaZip* zip, QString fileName, QString fileDest, const QString& baseDir = QString());
-    static std::pair<bool, bool> extractFile(QuaZip* zip, QString fileName, QString fileDest, const QByteArray& password, const QString& baseDir = QString());
-
     /// Remove some files.
     /**
       \param listFile The list of files to remove.

--- a/quazip/JlCompress.h
+++ b/quazip/JlCompress.h
@@ -121,7 +121,7 @@ public:
         // If set, used as last modified on file inside the archive.
         // If compressing a directory, used for all files.
         QDateTime m_dateTime;
-        
+
         CompressionStrategy m_compressionStrategy;
 
         /* Enables UTF-8 support for filenames and comments.

--- a/quazip/JlCompress.h
+++ b/quazip/JlCompress.h
@@ -164,6 +164,15 @@ public:
     static QString extractFile(QuaZip &zip, QString fileName, QString fileDest);
     static QStringList extractFiles(QuaZip &zip, const QStringList &files, const QString &dir);
 
+    /// Extract a single file.
+    /**
+      \param zip The opened zip archive to extract from.
+      \param fileName The full name of the file to extract.
+      \param fileDest The full path to the destination file.
+      \return true if success, false otherwise.
+      */
+    static bool extractFile(QuaZip* zip, QString fileName, QString fileDest);
+
     /// Compress a single file.
     /**
       \param zip Opened zip to compress the file to.

--- a/quazip/JlCompress.h
+++ b/quazip/JlCompress.h
@@ -305,6 +305,10 @@ public:
       with identical names.
       \warning On failure, the archive may be left in a partially modified state
       with some files already added.
+      \warning The UTF-8 flag in options MUST match the existing archive's encoding.
+      QuaZip does not auto-detect this. If the archive was created with UTF-8 enabled,
+      you must also enable UTF-8 when adding files, otherwise the archive will have
+      inconsistent filename encodings.
 
       \param fileCompressed The name of the existing archive.
       \param files The file list to add.
@@ -361,6 +365,10 @@ public:
       \warning The archive must already exist, or the operation will fail.
       \warning On failure, the archive may be left in a partially modified state
       with some files/directories already added.
+      \warning The UTF-8 flag in options MUST match the existing archive's encoding.
+      QuaZip does not auto-detect this. If the archive was created with UTF-8 enabled,
+      you must also enable UTF-8 when adding files, otherwise the archive will have
+      inconsistent filename encodings.
 
       \param fileCompressed The name of the existing archive.
       \param dir The directory to add.

--- a/quazip/JlCompress.h
+++ b/quazip/JlCompress.h
@@ -82,8 +82,9 @@ public:
 
         explicit Options(const QDateTime& dateTime = QDateTime(),
                          const CompressionStrategy& strategy = Default,
-                         bool utf8Enabled = false)
-            : m_dateTime(dateTime), m_compressionStrategy(strategy), m_utf8Enabled(utf8Enabled) {}
+                         bool utf8Enabled = false,
+                         const QByteArray& password = QByteArray())
+            : m_dateTime(dateTime), m_compressionStrategy(strategy), m_utf8Enabled(utf8Enabled), m_password(password) {}
 
         QDateTime getDateTime() const {
             return m_dateTime;
@@ -117,6 +118,14 @@ public:
             m_utf8Enabled = utf8Enabled;
         }
 
+        QByteArray getPassword() const {
+            return m_password;
+        }
+
+        void setPassword(const QByteArray &password) {
+            m_password = password;
+        }
+
     private:
         // If set, used as last modified on file inside the archive.
         // If compressing a directory, used for all files.
@@ -125,10 +134,28 @@ public:
         CompressionStrategy m_compressionStrategy;
 
         /* Enables UTF-8 support for filenames and comments.
-         * Must be set before QuaZip::open so only applicable to methods that open the zip internally.
-         * For methods which receive QuaZip* zip as an argument, you should set this flag before calling open on QuaZip object.
+         *
+         * For methods that create new archives (compressFile, compressFiles, compressDir):
+         *   - This flag determines the encoding for all files in the new archive.
+         *
+         * For methods that add to existing archives (addFile, addFiles, addDir):
+         *   - This flag MUST match the encoding already used in the existing archive.
+         *   - QuaZip does not auto-detect the existing encoding.
+         *   - Mismatched encoding will create an inconsistent archive.
+         *
+         * For methods that receive QuaZip* zip as an argument:
+         *   - This flag is ignored (zip is already opened).
+         *   - You must call setUtf8Enabled() on the QuaZip object before open().
          * */
         bool m_utf8Enabled;
+
+        /* Password for encryption/decryption.
+         *
+         * If set during compression, the files will be encrypted with this password.
+         * If set during extraction, this password will be used to decrypt the files.
+         * Empty password means no encryption/decryption.
+         * */
+        QByteArray m_password;
     };
 
     static bool copyData(QIODevice &inFile, QIODevice &outFile);
@@ -190,9 +217,17 @@ public:
       \param zip The opened zip archive to extract from.
       \param fileName The full name of the file to extract.
       \param fileDest The full path to the destination file.
-      \return true if success, false otherwise.
+      \param baseDir Base directory for path traversal validation (optional).
+      \param password Password for encrypted files (optional, second overload only).
+      \return std::pair<bool, bool> where:
+              - first: success status (true if extraction succeeded or file was safely skipped, false on error)
+              - second: wasSkipped status (true if file was skipped due to path traversal protection, false otherwise)
+
+      When path traversal is detected (file attempting to escape baseDir), the function returns {true, true}
+      to allow processing to continue while skipping the malicious file.
       */
-    static bool extractFile(QuaZip* zip, QString fileName, QString fileDest);
+    static std::pair<bool, bool> extractFile(QuaZip* zip, QString fileName, QString fileDest, const QString& baseDir = QString());
+    static std::pair<bool, bool> extractFile(QuaZip* zip, QString fileName, QString fileDest, const QByteArray& password, const QString& baseDir = QString());
 
     /// Remove some files.
     /**
@@ -445,6 +480,38 @@ public:
       \return The list of the full paths of the files extracted, empty on failure.
       */
     static QStringList extractDir(QString fileCompressed, QuazipTextCodec* fileNameCodec, QString dir = QString());
+
+    /// Extract a single file with password.
+    /**
+      \param fileCompressed The name of the archive.
+      \param fileName The file to extract.
+      \param fileDest The destination file, assumed to be identical to
+      \a fileName if left empty.
+      \param password Password for decryption (empty for no encryption).
+      \return The full path of the extracted file, empty on failure.
+      */
+    static QString extractFile(QString fileCompressed, QString fileName, QString fileDest, const QByteArray& password);
+
+    /// Extract a list of files with password.
+    /**
+      \param fileCompressed The name of the archive.
+      \param files The file list to extract.
+      \param dir The directory to put the files to, the current
+      directory if left empty.
+      \param password Password for decryption (empty for no encryption).
+      \return The list of the full paths of the files extracted, empty on failure.
+      */
+    static QStringList extractFiles(QString fileCompressed, QStringList files, QString dir, const QByteArray& password);
+
+    /// Extract a whole archive with password.
+    /**
+      \param fileCompressed The name of the archive.
+      \param dir The directory to extract to, the current directory if
+      left empty.
+      \param password Password for decryption (empty for no encryption).
+      \return The list of the full paths of the files extracted, empty on failure.
+      */
+    static QStringList extractDir(QString fileCompressed, QString dir, const QByteArray& password);
 
     /// Get the file list.
     /**

--- a/quazip/JlCompress.h
+++ b/quazip/JlCompress.h
@@ -78,10 +78,12 @@ public:
 
     public:
       	explicit Options(const CompressionStrategy& strategy)
-          : m_compressionStrategy(strategy) {}
+            : m_compressionStrategy(strategy) {}
 
-        explicit Options(const QDateTime& dateTime = QDateTime(), const CompressionStrategy& strategy = Default)
-            : m_dateTime(dateTime), m_compressionStrategy(strategy) {}
+        explicit Options(const QDateTime& dateTime = QDateTime(),
+                         const CompressionStrategy& strategy = Default,
+                         bool utf8Enabled = false)
+            : m_dateTime(dateTime), m_compressionStrategy(strategy), m_utf8Enabled(utf8Enabled) {}
 
         QDateTime getDateTime() const {
             return m_dateTime;
@@ -107,11 +109,26 @@ public:
             m_compressionStrategy = strategy;
         }
 
+        bool getUtf8Enabled() const {
+            return m_utf8Enabled;
+        }
+
+        void setUtf8Enabled(bool utf8Enabled) {
+            m_utf8Enabled = utf8Enabled;
+        }
+
     private:
         // If set, used as last modified on file inside the archive.
         // If compressing a directory, used for all files.
         QDateTime m_dateTime;
+        
         CompressionStrategy m_compressionStrategy;
+
+        /* Enables UTF-8 support for filenames and comments.
+         * Must be set before QuaZip::open so only applicable to methods that open the zip internally.
+         * For methods which receive QuaZip* zip as an argument, you should set this flag before calling open on QuaZip object.
+         * */
+        bool m_utf8Enabled;
     };
 
     static bool copyData(QIODevice &inFile, QIODevice &outFile);

--- a/quazip/JlCompress.h
+++ b/quazip/JlCompress.h
@@ -122,7 +122,7 @@ public:
             return m_password;
         }
 
-        void setPassword(const QByteArray &password) {
+        void setPassword(const QByteArray& password) {
             m_password = password;
         }
 

--- a/quazip/QuaCompress.cpp
+++ b/quazip/QuaCompress.cpp
@@ -61,89 +61,72 @@ QuaCompress& QuaCompress::withPassword(const QByteArray& password)
 
 // ==================== Compression Methods ====================
 
-bool QuaCompress::compressFile(QString fileCompressed, QString file)
+bool QuaCompress::compressFile(QString newArchive, QString file)
 {
-    return JlCompress::compressFile(fileCompressed, file, m_options);
+    return JlCompress::compressFile(newArchive, file, m_options);
 }
 
-bool QuaCompress::compressFiles(QString fileCompressed, QStringList files)
+bool QuaCompress::compressFiles(QString newArchive, QStringList files)
 {
-    return JlCompress::compressFiles(fileCompressed, files, m_options);
+    return JlCompress::compressFiles(newArchive, files, m_options);
 }
 
-bool QuaCompress::compressDir(QString fileCompressed, QString dir,
+bool QuaCompress::compressDir(QString newArchive, QString dir,
                                bool recursive, QDir::Filters filters)
 {
-    return JlCompress::compressDir(fileCompressed, dir, recursive, filters, m_options);
+    return JlCompress::compressDir(newArchive, dir, recursive, filters, m_options);
 }
 
 // ==================== Add to Existing Archive ====================
 
-bool QuaCompress::addFile(QString fileCompressed, QString file)
+bool QuaCompress::addFile(QString existingArchive, QString file)
 {
-    return JlCompress::addFile(fileCompressed, file, m_options);
+    return JlCompress::addFile(existingArchive, file, m_options);
 }
 
-bool QuaCompress::addFiles(QString fileCompressed, QStringList files)
+bool QuaCompress::addFiles(QString existingArchive, QStringList files)
 {
-    return JlCompress::addFiles(fileCompressed, files, m_options);
+    return JlCompress::addFiles(existingArchive, files, m_options);
 }
 
-bool QuaCompress::addDir(QString fileCompressed, QString dir,
+bool QuaCompress::addDir(QString existingArchive, QString dir,
                          bool recursive, QDir::Filters filters)
 {
-    return JlCompress::addDir(fileCompressed, dir, recursive, filters, m_options);
+    return JlCompress::addDir(existingArchive, dir, recursive, filters, m_options);
 }
 
 // ==================== Extraction Methods ====================
 
-QString QuaCompress::extractFile(QString fileCompressed, QString fileName, QString fileDest)
+QString QuaCompress::extractFile(QString archive, QString fileName, QString fileDest)
 {
     // Use password from options if set
     if (!m_options.getPassword().isEmpty()) {
-        return JlCompress::extractFile(fileCompressed, fileName, fileDest, m_options.getPassword());
+        return JlCompress::extractFile(archive, fileName, fileDest, m_options.getPassword());
     }
-    return JlCompress::extractFile(fileCompressed, fileName, fileDest);
+    return JlCompress::extractFile(archive, fileName, fileDest);
 }
 
-QStringList QuaCompress::extractFiles(QString fileCompressed, QStringList files, QString dir)
+QStringList QuaCompress::extractFiles(QString archive, QStringList files, QString dir)
 {
     // Use password from options if set
     if (!m_options.getPassword().isEmpty()) {
-        return JlCompress::extractFiles(fileCompressed, files, dir, m_options.getPassword());
+        return JlCompress::extractFiles(archive, files, dir, m_options.getPassword());
     }
-    return JlCompress::extractFiles(fileCompressed, files, dir);
+    return JlCompress::extractFiles(archive, files, dir);
 }
 
-QStringList QuaCompress::extractDir(QString fileCompressed, QString dir)
+QStringList QuaCompress::extractDir(QString archive, QString dir)
 {
     // Use password from options if set
     if (!m_options.getPassword().isEmpty()) {
-        return JlCompress::extractDir(fileCompressed, dir, m_options.getPassword());
+        return JlCompress::extractDir(archive, dir, m_options.getPassword());
     }
-    return JlCompress::extractDir(fileCompressed, dir);
+    return JlCompress::extractDir(archive, dir);
 }
 
-QStringList QuaCompress::extractDir(QString fileCompressed, QuazipTextCodec* fileNameCodec, QString dir)
+QStringList QuaCompress::extractDir(QString archive, QuazipTextCodec* fileNameCodec, QString dir)
 {
-    return JlCompress::extractDir(fileCompressed, fileNameCodec, dir);
-}
-
-// ==================== Extraction with Password ====================
-
-QString QuaCompress::extractFile(QString fileCompressed, QString fileName, QString fileDest, const QByteArray& password)
-{
-    return JlCompress::extractFile(fileCompressed, fileName, fileDest, password);
-}
-
-QStringList QuaCompress::extractFiles(QString fileCompressed, QStringList files, QString dir, const QByteArray& password)
-{
-    return JlCompress::extractFiles(fileCompressed, files, dir, password);
-}
-
-QStringList QuaCompress::extractDir(QString fileCompressed, QString dir, const QByteArray& password)
-{
-    return JlCompress::extractDir(fileCompressed, dir, password);
+    return JlCompress::extractDir(archive, fileNameCodec, dir);
 }
 
 // ==================== Extraction from QIODevice ====================
@@ -165,9 +148,9 @@ QStringList QuaCompress::extractDir(QIODevice* ioDevice, QuazipTextCodec* fileNa
 
 // ==================== Information Methods ====================
 
-QStringList QuaCompress::getFileList(QString fileCompressed)
+QStringList QuaCompress::getFileList(QString archive)
 {
-    return JlCompress::getFileList(fileCompressed);
+    return JlCompress::getFileList(archive);
 }
 
 QStringList QuaCompress::getFileList(QIODevice* ioDevice)

--- a/quazip/QuaCompress.cpp
+++ b/quazip/QuaCompress.cpp
@@ -22,6 +22,15 @@ See COPYING file for the full LGPL text.
 #include "QuaCompress.h"
 #include "JlCompress.h"
 
+// Define static constexpr members for C++14 compatibility (Qt5)
+constexpr QuaCompress::CompressionStrategy QuaCompress::Storage;
+constexpr QuaCompress::CompressionStrategy QuaCompress::Fastest;
+constexpr QuaCompress::CompressionStrategy QuaCompress::Faster;
+constexpr QuaCompress::CompressionStrategy QuaCompress::Standard;
+constexpr QuaCompress::CompressionStrategy QuaCompress::Better;
+constexpr QuaCompress::CompressionStrategy QuaCompress::Best;
+constexpr QuaCompress::CompressionStrategy QuaCompress::Default;
+
 QuaCompress::QuaCompress()
     : m_options(JlCompress::Options::Default)
 {

--- a/quazip/QuaCompress.cpp
+++ b/quazip/QuaCompress.cpp
@@ -22,18 +22,10 @@ See COPYING file for the full LGPL text.
 #include "QuaCompress.h"
 #include "JlCompress.h"
 
-// ==================== Constructor / Destructor ====================
-
 QuaCompress::QuaCompress()
-    : m_options()  // Default Options: utf8=false, compression=Default
+    : m_options(JlCompress::Options::Default)
 {
 }
-
-QuaCompress::~QuaCompress()
-{
-}
-
-// ==================== Configuration Methods (Fluent API) ====================
 
 QuaCompress& QuaCompress::withUtf8Enabled(bool enabled)
 {
@@ -41,7 +33,7 @@ QuaCompress& QuaCompress::withUtf8Enabled(bool enabled)
     return *this;
 }
 
-QuaCompress& QuaCompress::withCompression(CompressionStrategy strategy)
+QuaCompress& QuaCompress::withStrategy(CompressionStrategy strategy)
 {
     m_options.setCompressionStrategy(strategy);
     return *this;
@@ -59,101 +51,32 @@ QuaCompress& QuaCompress::withPassword(const QByteArray& password)
     return *this;
 }
 
-// ==================== Compression Methods ====================
-
-bool QuaCompress::compressFile(QString newArchive, QString file)
+bool QuaCompress::compressFile(const QString& newArchive, const QString& file) const
 {
     return JlCompress::compressFile(newArchive, file, m_options);
 }
 
-bool QuaCompress::compressFiles(QString newArchive, QStringList files)
+bool QuaCompress::compressFiles(const QString& newArchive, const QStringList& files) const
 {
     return JlCompress::compressFiles(newArchive, files, m_options);
 }
 
-bool QuaCompress::compressDir(QString newArchive, QString dir,
-                               bool recursive, QDir::Filters filters)
+bool QuaCompress::compressDir(const QString& newArchive, const QString& dir, const bool recursive, const QDir::Filters filters) const
 {
     return JlCompress::compressDir(newArchive, dir, recursive, filters, m_options);
 }
 
-// ==================== Add to Existing Archive ====================
-
-bool QuaCompress::addFile(QString existingArchive, QString file)
+bool QuaCompress::addFile(const QString& existingArchive, const QString& file) const
 {
     return JlCompress::addFile(existingArchive, file, m_options);
 }
 
-bool QuaCompress::addFiles(QString existingArchive, QStringList files)
+bool QuaCompress::addFiles(const QString& existingArchive, const QStringList& files) const
 {
     return JlCompress::addFiles(existingArchive, files, m_options);
 }
 
-bool QuaCompress::addDir(QString existingArchive, QString dir,
-                         bool recursive, QDir::Filters filters)
+bool QuaCompress::addDir(const QString& existingArchive, const QString& dir, const bool recursive, const QDir::Filters filters) const
 {
     return JlCompress::addDir(existingArchive, dir, recursive, filters, m_options);
-}
-
-// ==================== Extraction Methods ====================
-
-QString QuaCompress::extractFile(QString archive, QString fileName, QString fileDest)
-{
-    // Use password from options if set
-    if (!m_options.getPassword().isEmpty()) {
-        return JlCompress::extractFile(archive, fileName, fileDest, m_options.getPassword());
-    }
-    return JlCompress::extractFile(archive, fileName, fileDest);
-}
-
-QStringList QuaCompress::extractFiles(QString archive, QStringList files, QString dir)
-{
-    // Use password from options if set
-    if (!m_options.getPassword().isEmpty()) {
-        return JlCompress::extractFiles(archive, files, dir, m_options.getPassword());
-    }
-    return JlCompress::extractFiles(archive, files, dir);
-}
-
-QStringList QuaCompress::extractDir(QString archive, QString dir)
-{
-    // Use password from options if set
-    if (!m_options.getPassword().isEmpty()) {
-        return JlCompress::extractDir(archive, dir, m_options.getPassword());
-    }
-    return JlCompress::extractDir(archive, dir);
-}
-
-QStringList QuaCompress::extractDir(QString archive, QuazipTextCodec* fileNameCodec, QString dir)
-{
-    return JlCompress::extractDir(archive, fileNameCodec, dir);
-}
-
-// ==================== Extraction from QIODevice ====================
-
-QStringList QuaCompress::extractFiles(QIODevice* ioDevice, QStringList files, QString dir)
-{
-    return JlCompress::extractFiles(ioDevice, files, dir);
-}
-
-QStringList QuaCompress::extractDir(QIODevice* ioDevice, QString dir)
-{
-    return JlCompress::extractDir(ioDevice, dir);
-}
-
-QStringList QuaCompress::extractDir(QIODevice* ioDevice, QuazipTextCodec* fileNameCodec, QString dir)
-{
-    return JlCompress::extractDir(ioDevice, fileNameCodec, dir);
-}
-
-// ==================== Information Methods ====================
-
-QStringList QuaCompress::getFileList(QString archive)
-{
-    return JlCompress::getFileList(archive);
-}
-
-QStringList QuaCompress::getFileList(QIODevice* ioDevice)
-{
-    return JlCompress::getFileList(ioDevice);
 }

--- a/quazip/QuaCompress.cpp
+++ b/quazip/QuaCompress.cpp
@@ -1,0 +1,176 @@
+/*
+Copyright (C) 2025 cen1
+
+This file is part of QuaZip.
+
+QuaZip is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2.1 of the License, or
+(at your option) any later version.
+
+QuaZip is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with QuaZip.  If not, see <http://www.gnu.org/licenses/>.
+
+See COPYING file for the full LGPL text.
+*/
+
+#include "QuaCompress.h"
+#include "JlCompress.h"
+
+// ==================== Constructor / Destructor ====================
+
+QuaCompress::QuaCompress()
+    : m_options()  // Default Options: utf8=false, compression=Default
+{
+}
+
+QuaCompress::~QuaCompress()
+{
+}
+
+// ==================== Configuration Methods (Fluent API) ====================
+
+QuaCompress& QuaCompress::withUtf8Enabled(bool enabled)
+{
+    m_options.setUtf8Enabled(enabled);
+    return *this;
+}
+
+QuaCompress& QuaCompress::withCompression(CompressionStrategy strategy)
+{
+    m_options.setCompressionStrategy(strategy);
+    return *this;
+}
+
+QuaCompress& QuaCompress::withDateTime(const QDateTime& dateTime)
+{
+    m_options.setDateTime(dateTime);
+    return *this;
+}
+
+QuaCompress& QuaCompress::withPassword(const QByteArray& password)
+{
+    m_options.setPassword(password);
+    return *this;
+}
+
+// ==================== Compression Methods ====================
+
+bool QuaCompress::compressFile(QString fileCompressed, QString file)
+{
+    return JlCompress::compressFile(fileCompressed, file, m_options);
+}
+
+bool QuaCompress::compressFiles(QString fileCompressed, QStringList files)
+{
+    return JlCompress::compressFiles(fileCompressed, files, m_options);
+}
+
+bool QuaCompress::compressDir(QString fileCompressed, QString dir,
+                               bool recursive, QDir::Filters filters)
+{
+    return JlCompress::compressDir(fileCompressed, dir, recursive, filters, m_options);
+}
+
+// ==================== Add to Existing Archive ====================
+
+bool QuaCompress::addFile(QString fileCompressed, QString file)
+{
+    return JlCompress::addFile(fileCompressed, file, m_options);
+}
+
+bool QuaCompress::addFiles(QString fileCompressed, QStringList files)
+{
+    return JlCompress::addFiles(fileCompressed, files, m_options);
+}
+
+bool QuaCompress::addDir(QString fileCompressed, QString dir,
+                         bool recursive, QDir::Filters filters)
+{
+    return JlCompress::addDir(fileCompressed, dir, recursive, filters, m_options);
+}
+
+// ==================== Extraction Methods ====================
+
+QString QuaCompress::extractFile(QString fileCompressed, QString fileName, QString fileDest)
+{
+    // Use password from options if set
+    if (!m_options.getPassword().isEmpty()) {
+        return JlCompress::extractFile(fileCompressed, fileName, fileDest, m_options.getPassword());
+    }
+    return JlCompress::extractFile(fileCompressed, fileName, fileDest);
+}
+
+QStringList QuaCompress::extractFiles(QString fileCompressed, QStringList files, QString dir)
+{
+    // Use password from options if set
+    if (!m_options.getPassword().isEmpty()) {
+        return JlCompress::extractFiles(fileCompressed, files, dir, m_options.getPassword());
+    }
+    return JlCompress::extractFiles(fileCompressed, files, dir);
+}
+
+QStringList QuaCompress::extractDir(QString fileCompressed, QString dir)
+{
+    // Use password from options if set
+    if (!m_options.getPassword().isEmpty()) {
+        return JlCompress::extractDir(fileCompressed, dir, m_options.getPassword());
+    }
+    return JlCompress::extractDir(fileCompressed, dir);
+}
+
+QStringList QuaCompress::extractDir(QString fileCompressed, QuazipTextCodec* fileNameCodec, QString dir)
+{
+    return JlCompress::extractDir(fileCompressed, fileNameCodec, dir);
+}
+
+// ==================== Extraction with Password ====================
+
+QString QuaCompress::extractFile(QString fileCompressed, QString fileName, QString fileDest, const QByteArray& password)
+{
+    return JlCompress::extractFile(fileCompressed, fileName, fileDest, password);
+}
+
+QStringList QuaCompress::extractFiles(QString fileCompressed, QStringList files, QString dir, const QByteArray& password)
+{
+    return JlCompress::extractFiles(fileCompressed, files, dir, password);
+}
+
+QStringList QuaCompress::extractDir(QString fileCompressed, QString dir, const QByteArray& password)
+{
+    return JlCompress::extractDir(fileCompressed, dir, password);
+}
+
+// ==================== Extraction from QIODevice ====================
+
+QStringList QuaCompress::extractFiles(QIODevice* ioDevice, QStringList files, QString dir)
+{
+    return JlCompress::extractFiles(ioDevice, files, dir);
+}
+
+QStringList QuaCompress::extractDir(QIODevice* ioDevice, QString dir)
+{
+    return JlCompress::extractDir(ioDevice, dir);
+}
+
+QStringList QuaCompress::extractDir(QIODevice* ioDevice, QuazipTextCodec* fileNameCodec, QString dir)
+{
+    return JlCompress::extractDir(ioDevice, fileNameCodec, dir);
+}
+
+// ==================== Information Methods ====================
+
+QStringList QuaCompress::getFileList(QString fileCompressed)
+{
+    return JlCompress::getFileList(fileCompressed);
+}
+
+QStringList QuaCompress::getFileList(QIODevice* ioDevice)
+{
+    return JlCompress::getFileList(ioDevice);
+}

--- a/quazip/QuaCompress.h
+++ b/quazip/QuaCompress.h
@@ -2,7 +2,7 @@
 #define QUACOMPRESS_H
 
 /*
-Copyright (C) 2025cen1
+Copyright (C) 2025 cen1
 
 This file is part of QuaZip.
 
@@ -37,34 +37,8 @@ quazip/(un)zip.h files for details, basically it's zlib license.
 class QuaZip;
 class QIODevice;
 
-/// Utility class for compression/decompression with fluent API.
 /**
- * QuaCompress provides a modern fluent interface for working with ZIP archives.
- * It offers the same functionality as JlCompress but with method chaining for
- * better readability and flexibility.
- *
- * Example usage:
- * \code
- * // Create archive with UTF-8 encoding
- * QuaCompress()
- *     .withUtf8Enabled()
- *     .withCompression(JlCompress::Options::Better)
- *     .compressDir("archive.zip", "source_dir");
- *
- * // Add files to existing archive
- * QuaCompress()
- *     .withUtf8Enabled()
- *     .addFiles("archive.zip", fileList);
- *
- * // Extract with custom codec (matches JlCompress API)
- * QuaCompress().extractDir("archive.zip",
- *                          QuazipTextCodec::codecForName("Windows-1251"),
- *                          "output_dir");
- * \endcode
- *
- * For backwards compatibility, use JlCompress static methods instead.
- *
- * \sa JlCompress
+ * QuaCompress is a JlCompress equivalent with fluent api.
  */
 class QUAZIP_EXPORT QuaCompress {
 public:
@@ -80,19 +54,13 @@ public:
      */
     QuaCompress();
 
-    /// Destructor.
     ~QuaCompress();
-
-    // ==================== Configuration Methods (Fluent API) ====================
 
     /// Enable or disable UTF-8 encoding for file names and comments.
     /**
      * \param enabled If true, use UTF-8 encoding. If false, use the configured
      *                codec (or system default).
      * \return Reference to this instance for method chaining.
-     *
-     * \note When adding files to existing archives, this must match the encoding
-     *       already used in the archive to avoid inconsistencies.
      */
     QuaCompress& withUtf8Enabled(bool enabled = true);
 
@@ -105,7 +73,7 @@ public:
 
     /// Set the date/time to use for compressed files.
     /**
-     * \param dateTime The date/time to set. If invalid, current time will be used.
+     * \param dateTime The date/time to set. Default is to use current time.
      * \return Reference to this instance for method chaining.
      */
     QuaCompress& withDateTime(const QDateTime& dateTime);
@@ -115,40 +83,36 @@ public:
      * \param password The password to use for encrypting files during compression
      *                 or decrypting files during extraction.
      * \return Reference to this instance for method chaining.
-     *
-     * \note For compression, this password is used to encrypt all files added to the archive.
-     * \note For extraction, this password is used to decrypt password-protected files.
      */
     QuaCompress& withPassword(const QByteArray& password);
-
 
     // ==================== Compression Methods ====================
 
     /// Compress a single file.
     /**
-     * \param fileCompressed The name of the archive to create.
+     * \param newArchive The name of the archive to create.
      * \param file The file to compress.
      * \return true if successful, false otherwise.
      */
-    bool compressFile(QString fileCompressed, QString file);
+    bool compressFile(QString newArchive, QString file);
 
     /// Compress multiple files.
     /**
-     * \param fileCompressed The name of the archive to create.
+     * \param newArchive The name of the archive to create.
      * \param files List of files to compress.
      * \return true if successful, false otherwise.
      */
-    bool compressFiles(QString fileCompressed, QStringList files);
+    bool compressFiles(QString newArchive, QStringList files);
 
     /// Compress a directory.
     /**
-     * \param fileCompressed The name of the archive to create.
+     * \param newArchive The name of the archive to create.
      * \param dir The directory to compress. If empty, uses current directory.
      * \param recursive If true, include subdirectories recursively.
      * \param filters QDir filters to apply when selecting files.
      * \return true if successful, false otherwise.
      */
-    bool compressDir(QString fileCompressed, QString dir = QString(),
+    bool compressDir(QString newArchive, QString dir = QString(),
                      bool recursive = true,
                      QDir::Filters filters = QDir::AllEntries | QDir::NoDotAndDotDot);
 
@@ -156,35 +120,31 @@ public:
 
     /// Add a single file to an existing archive.
     /**
-     * \param fileCompressed The existing archive to add to.
+     * \param existingArchive The existing archive to add to.
      * \param file The file to add.
      * \return true if successful, false otherwise.
-     *
-     * \warning The UTF-8 setting must match the existing archive's encoding.
      */
-    bool addFile(QString fileCompressed, QString file);
+    bool addFile(QString existingArchive, QString file);
 
     /// Add multiple files to an existing archive.
     /**
-     * \param fileCompressed The existing archive to add to.
+     * \param existingArchive The existing archive to add to.
      * \param files List of files to add.
      * \return true if successful, false otherwise.
      *
      * \warning The UTF-8 setting must match the existing archive's encoding.
      */
-    bool addFiles(QString fileCompressed, QStringList files);
+    bool addFiles(QString existingArchive, QStringList files);
 
     /// Add a directory to an existing archive.
     /**
-     * \param fileCompressed The existing archive to add to.
+     * \param existingArchive The existing archive to add to.
      * \param dir The directory to add. If empty, uses current directory.
      * \param recursive If true, include subdirectories recursively.
      * \param filters QDir filters to apply when selecting files.
      * \return true if successful, false otherwise.
-     *
-     * \warning The UTF-8 setting must match the existing archive's encoding.
      */
-    bool addDir(QString fileCompressed, QString dir = QString(),
+    bool addDir(QString existingArchive, QString dir = QString(),
                 bool recursive = true,
                 QDir::Filters filters = QDir::AllEntries | QDir::NoDotAndDotDot);
 
@@ -192,70 +152,39 @@ public:
 
     /// Extract a single file from an archive.
     /**
-     * \param fileCompressed The archive to extract from.
+     * \param archive The archive to extract from.
      * \param fileName The file to extract from the archive.
      * \param fileDest Where to extract the file. If empty, extracts to current directory.
      * \return The full path to the extracted file, or empty string on failure.
      */
-    QString extractFile(QString fileCompressed, QString fileName, QString fileDest = QString());
+    QString extractFile(QString archive, QString fileName, QString fileDest = QString());
 
     /// Extract multiple files from an archive.
     /**
-     * \param fileCompressed The archive to extract from.
+     * \param archive The archive to extract from.
      * \param files List of files to extract (empty = extract all).
      * \param dir Destination directory. If empty, uses current directory.
      * \return List of extracted files, or empty list on failure.
      */
-    QStringList extractFiles(QString fileCompressed, QStringList files = QStringList(),
+    QStringList extractFiles(QString archive, QStringList files = QStringList(),
                              QString dir = QString());
 
     /// Extract entire archive.
     /**
-     * \param fileCompressed The archive to extract.
+     * \param archive The archive to extract.
      * \param dir Destination directory. If empty, uses current directory.
      * \return List of extracted files, or empty list on failure.
      */
-    QStringList extractDir(QString fileCompressed, QString dir = QString());
+    QStringList extractDir(QString archive, QString dir = QString());
 
     /// Extract entire archive with custom codec.
     /**
-     * \param fileCompressed The archive to extract.
+     * \param archive The archive to extract.
      * \param fileNameCodec The codec to use for file names.
      * \param dir Destination directory. If empty, uses current directory.
      * \return List of extracted files, or empty list on failure.
      */
-    QStringList extractDir(QString fileCompressed, QuazipTextCodec* fileNameCodec, QString dir = QString());
-
-    // ==================== Extraction with Password ====================
-
-    /// Extract a single file from a password-protected archive.
-    /**
-     * \param fileCompressed The archive to extract from.
-     * \param fileName The file to extract from the archive.
-     * \param fileDest Where to extract the file. If empty, extracts to current directory.
-     * \param password The password for decryption.
-     * \return The full path to the extracted file, or empty string on failure.
-     */
-    QString extractFile(QString fileCompressed, QString fileName, QString fileDest, const QByteArray& password);
-
-    /// Extract multiple files from a password-protected archive.
-    /**
-     * \param fileCompressed The archive to extract from.
-     * \param files List of files to extract.
-     * \param dir Destination directory. If empty, uses current directory.
-     * \param password The password for decryption.
-     * \return List of extracted files, or empty list on failure.
-     */
-    QStringList extractFiles(QString fileCompressed, QStringList files, QString dir, const QByteArray& password);
-
-    /// Extract entire password-protected archive.
-    /**
-     * \param fileCompressed The archive to extract.
-     * \param dir Destination directory. If empty, uses current directory.
-     * \param password The password for decryption.
-     * \return List of extracted files, or empty list on failure.
-     */
-    QStringList extractDir(QString fileCompressed, QString dir, const QByteArray& password);
+    QStringList extractDir(QString archive, QuazipTextCodec* fileNameCodec, QString dir = QString());
 
     // ==================== Extraction from QIODevice ====================
 
@@ -290,10 +219,10 @@ public:
 
     /// Get list of files in an archive.
     /**
-     * \param fileCompressed The archive to read.
+     * \param archive The archive to read.
      * \return List of file names in the archive, or empty list on failure.
      */
-    QStringList getFileList(QString fileCompressed);
+    QStringList getFileList(QString archive);
 
     /// Get list of files in an archive opened via QIODevice.
     /**
@@ -303,7 +232,6 @@ public:
     QStringList getFileList(QIODevice* ioDevice);
 
 private:
-    // Use JlCompress::Options to store configuration (avoid duplication)
     JlCompress::Options m_options;
 
     // Disable copy

--- a/quazip/QuaCompress.h
+++ b/quazip/QuaCompress.h
@@ -20,9 +20,6 @@ You should have received a copy of the GNU Lesser General Public License
 along with QuaZip.  If not, see <http://www.gnu.org/licenses/>.
 
 See COPYING file for the full LGPL text.
-
-Original ZIP package is copyrighted by Gilles Vollant, see
-quazip/(un)zip.h files for details, basically it's zlib license.
 */
 
 #include <QtCore/QString>
@@ -31,30 +28,35 @@ quazip/(un)zip.h files for details, basically it's zlib license.
 #include <QtCore/QDateTime>
 
 #include "quazip_global.h"
-#include "quazip_textcodec.h"
 #include "JlCompress.h"
 
-class QuaZip;
-class QIODevice;
-
 /**
- * QuaCompress is a JlCompress equivalent with fluent api.
+ * QuaCompress provides a fluent API for ZIP compression operations.
+ *
+ * Example usage:
+ * \code
+ * QuaCompress()
+ *     .withUtf8Enabled()
+ *     .withCompression(QuaCompress::Best)
+ *     .compressDir("archive.zip", "mydir/");
+ * \endcode
  */
 class QUAZIP_EXPORT QuaCompress {
 public:
     /// Compression strategy - shared with JlCompress::Options::CompressionStrategy.
     typedef JlCompress::Options::CompressionStrategy CompressionStrategy;
 
-    /// Constructs a QuaCompress instance with default settings.
-    /**
-     * Default settings:
-     * - UTF-8 encoding: disabled
-     * - Compression strategy: JlCompress::Options::Default
-     * - Date/time: current time (when compressing)
-     */
-    QuaCompress();
+    // Convenience constants for compression strategies
+    static constexpr CompressionStrategy Storage  = JlCompress::Options::Storage;
+    static constexpr CompressionStrategy Fastest  = JlCompress::Options::Fastest;
+    static constexpr CompressionStrategy Faster   = JlCompress::Options::Faster;
+    static constexpr CompressionStrategy Standard = JlCompress::Options::Standard;
+    static constexpr CompressionStrategy Better   = JlCompress::Options::Better;
+    static constexpr CompressionStrategy Best     = JlCompress::Options::Best;
+    static constexpr CompressionStrategy Default  = JlCompress::Options::Default;
 
-    ~QuaCompress();
+    /// Construct a QuaCompress instance.
+    QuaCompress();
 
     /// Enable or disable UTF-8 encoding for file names and comments.
     /**
@@ -69,7 +71,7 @@ public:
      * \param strategy The compression level to use.
      * \return Reference to this instance for method chaining.
      */
-    QuaCompress& withCompression(CompressionStrategy strategy);
+    QuaCompress& withStrategy(CompressionStrategy strategy);
 
     /// Set the date/time to use for compressed files.
     /**
@@ -78,10 +80,9 @@ public:
      */
     QuaCompress& withDateTime(const QDateTime& dateTime);
 
-    /// Set the password for encryption/decryption.
+    /// Set the password for encryption.
     /**
-     * \param password The password to use for encrypting files during compression
-     *                 or decrypting files during extraction.
+     * \param password The password to use for encrypting files during compression.
      * \return Reference to this instance for method chaining.
      */
     QuaCompress& withPassword(const QByteArray& password);
@@ -94,7 +95,7 @@ public:
      * \param file The file to compress.
      * \return true if successful, false otherwise.
      */
-    bool compressFile(QString newArchive, QString file);
+    bool compressFile(const QString& newArchive, const QString& file) const;
 
     /// Compress multiple files.
     /**
@@ -102,7 +103,7 @@ public:
      * \param files List of files to compress.
      * \return true if successful, false otherwise.
      */
-    bool compressFiles(QString newArchive, QStringList files);
+    bool compressFiles(const QString& newArchive, const QStringList& files) const;
 
     /// Compress a directory.
     /**
@@ -112,9 +113,9 @@ public:
      * \param filters QDir filters to apply when selecting files.
      * \return true if successful, false otherwise.
      */
-    bool compressDir(QString newArchive, QString dir = QString(),
+    bool compressDir(const QString& newArchive, const QString& dir = QString(),
                      bool recursive = true,
-                     QDir::Filters filters = QDir::AllEntries | QDir::NoDotAndDotDot);
+                     QDir::Filters filters = QDir::AllEntries | QDir::NoDotAndDotDot) const;
 
     // ==================== Add to Existing Archive ====================
 
@@ -124,7 +125,7 @@ public:
      * \param file The file to add.
      * \return true if successful, false otherwise.
      */
-    bool addFile(QString existingArchive, QString file);
+    bool addFile(const QString& existingArchive, const QString& file) const;
 
     /// Add multiple files to an existing archive.
     /**
@@ -134,7 +135,7 @@ public:
      *
      * \warning The UTF-8 setting must match the existing archive's encoding.
      */
-    bool addFiles(QString existingArchive, QStringList files);
+    bool addFiles(const QString& existingArchive, const QStringList& files) const;
 
     /// Add a directory to an existing archive.
     /**
@@ -144,99 +145,12 @@ public:
      * \param filters QDir filters to apply when selecting files.
      * \return true if successful, false otherwise.
      */
-    bool addDir(QString existingArchive, QString dir = QString(),
+    bool addDir(const QString& existingArchive, const QString& dir = QString(),
                 bool recursive = true,
-                QDir::Filters filters = QDir::AllEntries | QDir::NoDotAndDotDot);
-
-    // ==================== Extraction Methods ====================
-
-    /// Extract a single file from an archive.
-    /**
-     * \param archive The archive to extract from.
-     * \param fileName The file to extract from the archive.
-     * \param fileDest Where to extract the file. If empty, extracts to current directory.
-     * \return The full path to the extracted file, or empty string on failure.
-     */
-    QString extractFile(QString archive, QString fileName, QString fileDest = QString());
-
-    /// Extract multiple files from an archive.
-    /**
-     * \param archive The archive to extract from.
-     * \param files List of files to extract (empty = extract all).
-     * \param dir Destination directory. If empty, uses current directory.
-     * \return List of extracted files, or empty list on failure.
-     */
-    QStringList extractFiles(QString archive, QStringList files = QStringList(),
-                             QString dir = QString());
-
-    /// Extract entire archive.
-    /**
-     * \param archive The archive to extract.
-     * \param dir Destination directory. If empty, uses current directory.
-     * \return List of extracted files, or empty list on failure.
-     */
-    QStringList extractDir(QString archive, QString dir = QString());
-
-    /// Extract entire archive with custom codec.
-    /**
-     * \param archive The archive to extract.
-     * \param fileNameCodec The codec to use for file names.
-     * \param dir Destination directory. If empty, uses current directory.
-     * \return List of extracted files, or empty list on failure.
-     */
-    QStringList extractDir(QString archive, QuazipTextCodec* fileNameCodec, QString dir = QString());
-
-    // ==================== Extraction from QIODevice ====================
-
-    /// Extract multiple files from an archive opened via QIODevice.
-    /**
-     * \param ioDevice The QIODevice to read the archive from.
-     * \param files List of files to extract (empty = extract all).
-     * \param dir Destination directory. If empty, uses current directory.
-     * \return List of extracted files, or empty list on failure.
-     */
-    QStringList extractFiles(QIODevice* ioDevice, QStringList files = QStringList(),
-                             QString dir = QString());
-
-    /// Extract entire archive from QIODevice.
-    /**
-     * \param ioDevice The QIODevice to read the archive from.
-     * \param dir Destination directory. If empty, uses current directory.
-     * \return List of extracted files, or empty list on failure.
-     */
-    QStringList extractDir(QIODevice* ioDevice, QString dir = QString());
-
-    /// Extract entire archive from QIODevice with custom codec.
-    /**
-     * \param ioDevice The QIODevice to read the archive from.
-     * \param fileNameCodec The codec to use for file names.
-     * \param dir Destination directory. If empty, uses current directory.
-     * \return List of extracted files, or empty list on failure.
-     */
-    QStringList extractDir(QIODevice* ioDevice, QuazipTextCodec* fileNameCodec, QString dir = QString());
-
-    // ==================== Information Methods ====================
-
-    /// Get list of files in an archive.
-    /**
-     * \param archive The archive to read.
-     * \return List of file names in the archive, or empty list on failure.
-     */
-    QStringList getFileList(QString archive);
-
-    /// Get list of files in an archive opened via QIODevice.
-    /**
-     * \param ioDevice The QIODevice to read the archive from.
-     * \return List of file names in the archive, or empty list on failure.
-     */
-    QStringList getFileList(QIODevice* ioDevice);
+                QDir::Filters filters = QDir::AllEntries | QDir::NoDotAndDotDot) const;
 
 private:
     JlCompress::Options m_options;
-
-    // Disable copy
-    QuaCompress(const QuaCompress&) = delete;
-    QuaCompress& operator=(const QuaCompress&) = delete;
 };
 
 #endif // QUACOMPRESS_H

--- a/quazip/QuaCompress.h
+++ b/quazip/QuaCompress.h
@@ -1,0 +1,314 @@
+#ifndef QUACOMPRESS_H
+#define QUACOMPRESS_H
+
+/*
+Copyright (C) 2025cen1
+
+This file is part of QuaZip.
+
+QuaZip is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2.1 of the License, or
+(at your option) any later version.
+
+QuaZip is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with QuaZip.  If not, see <http://www.gnu.org/licenses/>.
+
+See COPYING file for the full LGPL text.
+
+Original ZIP package is copyrighted by Gilles Vollant, see
+quazip/(un)zip.h files for details, basically it's zlib license.
+*/
+
+#include <QtCore/QString>
+#include <QtCore/QStringList>
+#include <QtCore/QDir>
+#include <QtCore/QDateTime>
+
+#include "quazip_global.h"
+#include "quazip_textcodec.h"
+#include "JlCompress.h"
+
+class QuaZip;
+class QIODevice;
+
+/// Utility class for compression/decompression with fluent API.
+/**
+ * QuaCompress provides a modern fluent interface for working with ZIP archives.
+ * It offers the same functionality as JlCompress but with method chaining for
+ * better readability and flexibility.
+ *
+ * Example usage:
+ * \code
+ * // Create archive with UTF-8 encoding
+ * QuaCompress()
+ *     .withUtf8Enabled()
+ *     .withCompression(JlCompress::Options::Better)
+ *     .compressDir("archive.zip", "source_dir");
+ *
+ * // Add files to existing archive
+ * QuaCompress()
+ *     .withUtf8Enabled()
+ *     .addFiles("archive.zip", fileList);
+ *
+ * // Extract with custom codec (matches JlCompress API)
+ * QuaCompress().extractDir("archive.zip",
+ *                          QuazipTextCodec::codecForName("Windows-1251"),
+ *                          "output_dir");
+ * \endcode
+ *
+ * For backwards compatibility, use JlCompress static methods instead.
+ *
+ * \sa JlCompress
+ */
+class QUAZIP_EXPORT QuaCompress {
+public:
+    /// Compression strategy - shared with JlCompress::Options::CompressionStrategy.
+    typedef JlCompress::Options::CompressionStrategy CompressionStrategy;
+
+    /// Constructs a QuaCompress instance with default settings.
+    /**
+     * Default settings:
+     * - UTF-8 encoding: disabled
+     * - Compression strategy: JlCompress::Options::Default
+     * - Date/time: current time (when compressing)
+     */
+    QuaCompress();
+
+    /// Destructor.
+    ~QuaCompress();
+
+    // ==================== Configuration Methods (Fluent API) ====================
+
+    /// Enable or disable UTF-8 encoding for file names and comments.
+    /**
+     * \param enabled If true, use UTF-8 encoding. If false, use the configured
+     *                codec (or system default).
+     * \return Reference to this instance for method chaining.
+     *
+     * \note When adding files to existing archives, this must match the encoding
+     *       already used in the archive to avoid inconsistencies.
+     */
+    QuaCompress& withUtf8Enabled(bool enabled = true);
+
+    /// Set the compression strategy/level.
+    /**
+     * \param strategy The compression level to use.
+     * \return Reference to this instance for method chaining.
+     */
+    QuaCompress& withCompression(CompressionStrategy strategy);
+
+    /// Set the date/time to use for compressed files.
+    /**
+     * \param dateTime The date/time to set. If invalid, current time will be used.
+     * \return Reference to this instance for method chaining.
+     */
+    QuaCompress& withDateTime(const QDateTime& dateTime);
+
+    /// Set the password for encryption/decryption.
+    /**
+     * \param password The password to use for encrypting files during compression
+     *                 or decrypting files during extraction.
+     * \return Reference to this instance for method chaining.
+     *
+     * \note For compression, this password is used to encrypt all files added to the archive.
+     * \note For extraction, this password is used to decrypt password-protected files.
+     */
+    QuaCompress& withPassword(const QByteArray& password);
+
+
+    // ==================== Compression Methods ====================
+
+    /// Compress a single file.
+    /**
+     * \param fileCompressed The name of the archive to create.
+     * \param file The file to compress.
+     * \return true if successful, false otherwise.
+     */
+    bool compressFile(QString fileCompressed, QString file);
+
+    /// Compress multiple files.
+    /**
+     * \param fileCompressed The name of the archive to create.
+     * \param files List of files to compress.
+     * \return true if successful, false otherwise.
+     */
+    bool compressFiles(QString fileCompressed, QStringList files);
+
+    /// Compress a directory.
+    /**
+     * \param fileCompressed The name of the archive to create.
+     * \param dir The directory to compress. If empty, uses current directory.
+     * \param recursive If true, include subdirectories recursively.
+     * \param filters QDir filters to apply when selecting files.
+     * \return true if successful, false otherwise.
+     */
+    bool compressDir(QString fileCompressed, QString dir = QString(),
+                     bool recursive = true,
+                     QDir::Filters filters = QDir::AllEntries | QDir::NoDotAndDotDot);
+
+    // ==================== Add to Existing Archive ====================
+
+    /// Add a single file to an existing archive.
+    /**
+     * \param fileCompressed The existing archive to add to.
+     * \param file The file to add.
+     * \return true if successful, false otherwise.
+     *
+     * \warning The UTF-8 setting must match the existing archive's encoding.
+     */
+    bool addFile(QString fileCompressed, QString file);
+
+    /// Add multiple files to an existing archive.
+    /**
+     * \param fileCompressed The existing archive to add to.
+     * \param files List of files to add.
+     * \return true if successful, false otherwise.
+     *
+     * \warning The UTF-8 setting must match the existing archive's encoding.
+     */
+    bool addFiles(QString fileCompressed, QStringList files);
+
+    /// Add a directory to an existing archive.
+    /**
+     * \param fileCompressed The existing archive to add to.
+     * \param dir The directory to add. If empty, uses current directory.
+     * \param recursive If true, include subdirectories recursively.
+     * \param filters QDir filters to apply when selecting files.
+     * \return true if successful, false otherwise.
+     *
+     * \warning The UTF-8 setting must match the existing archive's encoding.
+     */
+    bool addDir(QString fileCompressed, QString dir = QString(),
+                bool recursive = true,
+                QDir::Filters filters = QDir::AllEntries | QDir::NoDotAndDotDot);
+
+    // ==================== Extraction Methods ====================
+
+    /// Extract a single file from an archive.
+    /**
+     * \param fileCompressed The archive to extract from.
+     * \param fileName The file to extract from the archive.
+     * \param fileDest Where to extract the file. If empty, extracts to current directory.
+     * \return The full path to the extracted file, or empty string on failure.
+     */
+    QString extractFile(QString fileCompressed, QString fileName, QString fileDest = QString());
+
+    /// Extract multiple files from an archive.
+    /**
+     * \param fileCompressed The archive to extract from.
+     * \param files List of files to extract (empty = extract all).
+     * \param dir Destination directory. If empty, uses current directory.
+     * \return List of extracted files, or empty list on failure.
+     */
+    QStringList extractFiles(QString fileCompressed, QStringList files = QStringList(),
+                             QString dir = QString());
+
+    /// Extract entire archive.
+    /**
+     * \param fileCompressed The archive to extract.
+     * \param dir Destination directory. If empty, uses current directory.
+     * \return List of extracted files, or empty list on failure.
+     */
+    QStringList extractDir(QString fileCompressed, QString dir = QString());
+
+    /// Extract entire archive with custom codec.
+    /**
+     * \param fileCompressed The archive to extract.
+     * \param fileNameCodec The codec to use for file names.
+     * \param dir Destination directory. If empty, uses current directory.
+     * \return List of extracted files, or empty list on failure.
+     */
+    QStringList extractDir(QString fileCompressed, QuazipTextCodec* fileNameCodec, QString dir = QString());
+
+    // ==================== Extraction with Password ====================
+
+    /// Extract a single file from a password-protected archive.
+    /**
+     * \param fileCompressed The archive to extract from.
+     * \param fileName The file to extract from the archive.
+     * \param fileDest Where to extract the file. If empty, extracts to current directory.
+     * \param password The password for decryption.
+     * \return The full path to the extracted file, or empty string on failure.
+     */
+    QString extractFile(QString fileCompressed, QString fileName, QString fileDest, const QByteArray& password);
+
+    /// Extract multiple files from a password-protected archive.
+    /**
+     * \param fileCompressed The archive to extract from.
+     * \param files List of files to extract.
+     * \param dir Destination directory. If empty, uses current directory.
+     * \param password The password for decryption.
+     * \return List of extracted files, or empty list on failure.
+     */
+    QStringList extractFiles(QString fileCompressed, QStringList files, QString dir, const QByteArray& password);
+
+    /// Extract entire password-protected archive.
+    /**
+     * \param fileCompressed The archive to extract.
+     * \param dir Destination directory. If empty, uses current directory.
+     * \param password The password for decryption.
+     * \return List of extracted files, or empty list on failure.
+     */
+    QStringList extractDir(QString fileCompressed, QString dir, const QByteArray& password);
+
+    // ==================== Extraction from QIODevice ====================
+
+    /// Extract multiple files from an archive opened via QIODevice.
+    /**
+     * \param ioDevice The QIODevice to read the archive from.
+     * \param files List of files to extract (empty = extract all).
+     * \param dir Destination directory. If empty, uses current directory.
+     * \return List of extracted files, or empty list on failure.
+     */
+    QStringList extractFiles(QIODevice* ioDevice, QStringList files = QStringList(),
+                             QString dir = QString());
+
+    /// Extract entire archive from QIODevice.
+    /**
+     * \param ioDevice The QIODevice to read the archive from.
+     * \param dir Destination directory. If empty, uses current directory.
+     * \return List of extracted files, or empty list on failure.
+     */
+    QStringList extractDir(QIODevice* ioDevice, QString dir = QString());
+
+    /// Extract entire archive from QIODevice with custom codec.
+    /**
+     * \param ioDevice The QIODevice to read the archive from.
+     * \param fileNameCodec The codec to use for file names.
+     * \param dir Destination directory. If empty, uses current directory.
+     * \return List of extracted files, or empty list on failure.
+     */
+    QStringList extractDir(QIODevice* ioDevice, QuazipTextCodec* fileNameCodec, QString dir = QString());
+
+    // ==================== Information Methods ====================
+
+    /// Get list of files in an archive.
+    /**
+     * \param fileCompressed The archive to read.
+     * \return List of file names in the archive, or empty list on failure.
+     */
+    QStringList getFileList(QString fileCompressed);
+
+    /// Get list of files in an archive opened via QIODevice.
+    /**
+     * \param ioDevice The QIODevice to read the archive from.
+     * \return List of file names in the archive, or empty list on failure.
+     */
+    QStringList getFileList(QIODevice* ioDevice);
+
+private:
+    // Use JlCompress::Options to store configuration (avoid duplication)
+    JlCompress::Options m_options;
+
+    // Disable copy
+    QuaCompress(const QuaCompress&) = delete;
+    QuaCompress& operator=(const QuaCompress&) = delete;
+};
+
+#endif // QUACOMPRESS_H

--- a/quazip/QuaExtract.cpp
+++ b/quazip/QuaExtract.cpp
@@ -1,0 +1,78 @@
+/*
+Copyright (C) 2025 cen1
+
+This file is part of QuaZip.
+
+QuaZip is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2.1 of the License, or
+(at your option) any later version.
+
+QuaZip is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with QuaZip.  If not, see <http://www.gnu.org/licenses/>.
+
+See COPYING file for the full LGPL text.
+*/
+
+#include "QuaExtract.h"
+#include "JlCompress.h"
+
+QuaExtract::QuaExtract()
+{
+}
+
+QuaExtract& QuaExtract::withPassword(const QByteArray& password)
+{
+    m_password = password;
+    return *this;
+}
+
+QString QuaExtract::extractFile(const QString& archive, const QString& fileName, const QString& fileDest) const
+{
+    return JlCompress::extractFile(archive, fileName, fileDest, m_password);
+}
+
+QStringList QuaExtract::extractFiles(const QString& archive, const QStringList& files, const QString& dir) const
+{
+    return JlCompress::extractFiles(archive, files, dir, m_password);
+}
+
+QStringList QuaExtract::extractDir(const QString& archive, const QString& dir) const
+{
+    return JlCompress::extractDir(archive, dir, m_password);
+}
+
+QStringList QuaExtract::extractDir(const QString& archive, QuazipTextCodec* fileNameCodec, const QString& dir) const
+{
+    return JlCompress::extractDir(archive, fileNameCodec, dir);
+}
+
+QStringList QuaExtract::extractFiles(QIODevice* ioDevice, const QStringList& files, const QString& dir) const
+{
+    return JlCompress::extractFiles(ioDevice, files, dir);
+}
+
+QStringList QuaExtract::extractDir(QIODevice* ioDevice, const QString& dir) const
+{
+    return JlCompress::extractDir(ioDevice, dir);
+}
+
+QStringList QuaExtract::extractDir(QIODevice* ioDevice, QuazipTextCodec* fileNameCodec, const QString& dir) const
+{
+    return JlCompress::extractDir(ioDevice, fileNameCodec, dir);
+}
+
+QStringList QuaExtract::getFileList(const QString& archive) const
+{
+    return JlCompress::getFileList(archive);
+}
+
+QStringList QuaExtract::getFileList(QIODevice* ioDevice) const
+{
+    return JlCompress::getFileList(ioDevice);
+}

--- a/quazip/QuaExtract.h
+++ b/quazip/QuaExtract.h
@@ -1,0 +1,142 @@
+#ifndef QUAEXTRACT_H
+#define QUAEXTRACT_H
+
+/*
+Copyright (C) 2025 cen1
+
+This file is part of QuaZip.
+
+QuaZip is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2.1 of the License, or
+(at your option) any later version.
+
+QuaZip is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with QuaZip.  If not, see <http://www.gnu.org/licenses/>.
+
+See COPYING file for the full LGPL text.
+*/
+
+#include <QtCore/QString>
+#include <QtCore/QStringList>
+
+#include "quazip_global.h"
+#include "quazip_textcodec.h"
+
+class QIODevice;
+
+/**
+ * QuaExtract provides a fluent API for ZIP extraction operations.
+ *
+ * Example usage:
+ * \code
+ * QuaExtract()
+ *     .withPassword("secret")
+ *     .extractDir("archive.zip", "output/");
+ * \endcode
+ */
+class QUAZIP_EXPORT QuaExtract {
+public:
+    /// Construct a QuaExtract instance.
+    QuaExtract();
+
+    /// Set the password for decryption.
+    /**
+     * \param password The password to use for decrypting files during extraction.
+     * \return Reference to this instance for method chaining.
+     */
+    QuaExtract& withPassword(const QByteArray& password);
+
+    // ==================== Extraction Methods ====================
+
+    /// Extract a single file from an archive.
+    /**
+     * \param archive The archive to extract from.
+     * \param fileName The file to extract from the archive.
+     * \param fileDest Where to extract the file. If empty, extracts to current directory.
+     * \return The full path to the extracted file, or empty string on failure.
+     */
+    QString extractFile(const QString& archive, const QString& fileName, const QString& fileDest = QString()) const;
+
+    /// Extract multiple files from an archive.
+    /**
+     * \param archive The archive to extract from.
+     * \param files List of files to extract (empty = extract all).
+     * \param dir Destination directory. If empty, uses current directory.
+     * \return List of extracted files, or empty list on failure.
+     */
+    QStringList extractFiles(const QString& archive, const QStringList& files = QStringList(),
+                             const QString& dir = QString()) const;
+
+    /// Extract entire archive.
+    /**
+     * \param archive The archive to extract.
+     * \param dir Destination directory. If empty, uses current directory.
+     * \return List of extracted files, or empty list on failure.
+     */
+    QStringList extractDir(const QString& archive, const QString& dir = QString()) const;
+
+    /// Extract entire archive with custom codec.
+    /**
+     * \param archive The archive to extract.
+     * \param fileNameCodec The codec to use for file names.
+     * \param dir Destination directory. If empty, uses current directory.
+     * \return List of extracted files, or empty list on failure.
+     */
+    QStringList extractDir(const QString& archive, QuazipTextCodec* fileNameCodec, const QString& dir = QString()) const;
+
+    // ==================== Extraction from QIODevice ====================
+
+    /// Extract multiple files from an archive opened via QIODevice.
+    /**
+     * \param ioDevice The QIODevice to read the archive from.
+     * \param files List of files to extract (empty = extract all).
+     * \param dir Destination directory. If empty, uses current directory.
+     * \return List of extracted files, or empty list on failure.
+     */
+    QStringList extractFiles(QIODevice* ioDevice, const QStringList& files = QStringList(),
+                             const QString& dir = QString()) const;
+
+    /// Extract entire archive from QIODevice.
+    /**
+     * \param ioDevice The QIODevice to read the archive from.
+     * \param dir Destination directory. If empty, uses current directory.
+     * \return List of extracted files, or empty list on failure.
+     */
+    QStringList extractDir(QIODevice* ioDevice, const QString& dir = QString()) const;
+
+    /// Extract entire archive from QIODevice with custom codec.
+    /**
+     * \param ioDevice The QIODevice to read the archive from.
+     * \param fileNameCodec The codec to use for file names.
+     * \param dir Destination directory. If empty, uses current directory.
+     * \return List of extracted files, or empty list on failure.
+     */
+    QStringList extractDir(QIODevice* ioDevice, QuazipTextCodec* fileNameCodec, const QString& dir = QString()) const;
+
+    // ==================== Information Methods ====================
+
+    /// Get list of files in an archive.
+    /**
+     * \param archive The archive to read.
+     * \return List of file names in the archive, or empty list on failure.
+     */
+    QStringList getFileList(const QString& archive) const;
+
+    /// Get list of files in an archive opened via QIODevice.
+    /**
+     * \param ioDevice The QIODevice to read the archive from.
+     * \return List of file names in the archive, or empty list on failure.
+     */
+    QStringList getFileList(QIODevice* ioDevice) const;
+
+private:
+    QByteArray m_password;
+};
+
+#endif // QUAEXTRACT_H

--- a/quazip/quazip.cpp
+++ b/quazip/quazip.cpp
@@ -581,13 +581,13 @@ QString QuaZip::getCurrentFileName()const
     return QString();
   fileName.resize(file_info.size_filename);
 
-  if (file_info.flag & UNZ_ENCODING_UTF8) {
+  /*if (file_info.flag & UNZ_ENCODING_UTF8) {
     qDebug() << "Using UTF8";
   }
   else {
     //QString pp = p->fileNameCodec->toUnicode(fileName);
     qDebug() << "Using default codec";
-  }
+  }*/
 
   QString result = (file_info.flag & UNZ_ENCODING_UTF8)
     ? QString::fromUtf8(fileName) : p->fileNameCodec->toUnicode(fileName);

--- a/quazip/quazip.cpp
+++ b/quazip/quazip.cpp
@@ -25,6 +25,7 @@ quazip/(un)zip.h files for details, basically it's zlib license.
 #include <QtCore/QFile>
 #include <QtCore/QFlags>
 #include <QtCore/QHash>
+#include <QDebug>
 
 #include "quazip.h"
 

--- a/quazip/quazip.cpp
+++ b/quazip/quazip.cpp
@@ -585,7 +585,7 @@ QString QuaZip::getCurrentFileName()const
   }
   else {
     //QString pp = p->fileNameCodec->toUnicode(fileName);
-    qDebug() << p->fileNameCodec->name();
+    qDebug() << "Using default codec";
   }
 
   QString result = (file_info.flag & UNZ_ENCODING_UTF8)

--- a/quazip/quazip.cpp
+++ b/quazip/quazip.cpp
@@ -579,6 +579,15 @@ QString QuaZip::getCurrentFileName()const
       nullptr, 0, nullptr, 0))!=UNZ_OK)
     return QString();
   fileName.resize(file_info.size_filename);
+
+  if (file_info.flag & UNZ_ENCODING_UTF8) {
+    qDebug() << "Using UTF8";
+  }
+  else {
+    //QString pp = p->fileNameCodec->toUnicode(fileName);
+    qDebug() << p->fileNameCodec->name();
+  }
+
   QString result = (file_info.flag & UNZ_ENCODING_UTF8)
     ? QString::fromUtf8(fileName) : p->fileNameCodec->toUnicode(fileName);
   if (result.isEmpty())

--- a/qztest/CMakeLists.txt
+++ b/qztest/CMakeLists.txt
@@ -12,6 +12,8 @@ set(QZTEST_SOURCES
         testquazipfile.h
         testquazipfileinfo.h
         testquazipnewinfo.h
+        testutf8_compress.h
+        testutf8_decompress.h
         qztest.cpp
         testjlcompress.cpp
         testjlcp_compress.cpp
@@ -25,6 +27,8 @@ set(QZTEST_SOURCES
         testquazipfile.cpp
         testquazipfileinfo.cpp
         testquazipnewinfo.cpp
+        testutf8_compress.cpp
+        testutf8_decompress.cpp
 )
 
 add_executable(qztest ${QZTEST_SOURCES} qztest.qrc)

--- a/qztest/CMakeLists.txt
+++ b/qztest/CMakeLists.txt
@@ -4,6 +4,7 @@ set(QZTEST_SOURCES
         testjlcp_compress.h
         testjlcp_extract.h
         testquachecksum32.h
+        testquacompress.h
         testquagzipfile.h
         testquaziodevice.h
         testquazip.h
@@ -16,6 +17,7 @@ set(QZTEST_SOURCES
         testjlcp_compress.cpp
         testjlcp_extract.cpp
         testquachecksum32.cpp
+        testquacompress.cpp
         testquagzipfile.cpp
         testquaziodevice.cpp
         testquazip.cpp

--- a/qztest/qztest.cpp
+++ b/qztest/qztest.cpp
@@ -50,6 +50,10 @@ see quazip/(un)zip.h files for details. Basically it's the zlib license.
 
 #include <QtTest/QTest>
 
+#ifdef QUAZIP_CAN_USE_QTEXTCODEC
+#include <QTextCodec>
+#endif
+
 bool createTestFiles(const QStringList &fileNames, int size, const QString &dir)
 {
     QDir curDir;

--- a/qztest/qztest.cpp
+++ b/qztest/qztest.cpp
@@ -283,6 +283,7 @@ void removeTestFiles(const QStringList &fileNames, const QString &dir)
 bool isPlatformUtf8()
 {
 #ifdef QUAZIP_CAN_USE_QTEXTCODEC
+    // Qt 5: Check the actual codec
     QTextCodec *defaultCodec = QTextCodec::codecForLocale();
     if (defaultCodec) {
         QByteArray codecName = defaultCodec->name().toLower();
@@ -290,10 +291,16 @@ bool isPlatformUtf8()
     }
     return false;
 #else
-    // Qt6: check locale environment
-    QByteArray locale = qgetenv("LC_ALL");
-    if (locale.isEmpty()) locale = qgetenv("LANG");
-    return locale.contains("UTF-8") || locale.contains("utf8");
+    // Qt 6: Platform-specific behavior
+#ifdef Q_OS_WIN
+    // Windows: UTF-8 support depends on the archive having UTF-8 flag set,
+    // not on the "platform" encoding. Return false to indicate platform
+    // does not guarantee UTF-8 without the flag.
+    return false;
+#else
+    // Linux/Unix: Qt 6 forces UTF-8 encoding regardless of locale
+    return true;
+#endif
 #endif
 }
 

--- a/qztest/qztest.cpp
+++ b/qztest/qztest.cpp
@@ -35,6 +35,8 @@ see quazip/(un)zip.h files for details. Basically it's the zlib license.
 #include "testquazipfile.h"
 #include "testquazipfileinfo.h"
 #include "testquazipnewinfo.h"
+#include "testutf8_compress.h"
+#include "testutf8_decompress.h"
 
 #include <quazip.h>
 #include <quazipfile.h>
@@ -274,6 +276,23 @@ void removeTestFiles(const QStringList &fileNames, const QString &dir)
     }
 }
 
+bool isPlatformUtf8()
+{
+#ifdef QUAZIP_CAN_USE_QTEXTCODEC
+    QTextCodec *defaultCodec = QTextCodec::codecForLocale();
+    if (defaultCodec) {
+        QByteArray codecName = defaultCodec->name().toLower();
+        return codecName.contains("utf-8") || codecName.contains("utf8");
+    }
+    return false;
+#else
+    // Qt6: check locale environment
+    QByteArray locale = qgetenv("LC_ALL");
+    if (locale.isEmpty()) locale = qgetenv("LANG");
+    return locale.contains("UTF-8") || locale.contains("utf8");
+#endif
+}
+
 int main(int argc, char **argv)
 {
     QCoreApplication app(argc, argv);
@@ -327,6 +346,16 @@ int main(int argc, char **argv)
     {
       TestJlCpExtract testJlCpExtract;
       err = qMax(err, QTest::qExec(&testJlCpExtract, app.arguments()));
+    }
+    if (QString(qgetenv("TEST_UTF8_COMPRESS")) == "true")
+    {
+      TestUtf8Compress testUtf8Compress;
+      err = qMax(err, QTest::qExec(&testUtf8Compress, app.arguments()));
+    }
+    if (QString(qgetenv("TEST_UTF8_DECOMPRESS")) == "true")
+    {
+      TestUtf8Decompress testUtf8Decompress;
+      err = qMax(err, QTest::qExec(&testUtf8Decompress, app.arguments()));
     }
 
     if (err == 0) {

--- a/qztest/qztest.cpp
+++ b/qztest/qztest.cpp
@@ -27,6 +27,7 @@ see quazip/(un)zip.h files for details. Basically it's the zlib license.
 #include "testjlcp_compress.h"
 #include "testjlcp_extract.h"
 #include "testquachecksum32.h"
+#include "testquacompress.h"
 #include "testquagzipfile.h"
 #include "testquaziodevice.h"
 #include "testquazip.h"
@@ -292,6 +293,10 @@ int main(int argc, char **argv)
     {
         TestJlCompress testJlCompress;
         err = qMax(err, QTest::qExec(&testJlCompress, app.arguments()));
+    }
+    {
+        TestQuaCompress testQuaCompress;
+        err = qMax(err, QTest::qExec(&testQuaCompress, app.arguments()));
     }
     {
         TestQuaZipDir testQuaZipDir;

--- a/qztest/qztest.cpp
+++ b/qztest/qztest.cpp
@@ -352,6 +352,10 @@ int main(int argc, char **argv)
             err = qMax(err, QTest::qExec(&testQuaCompress, app.arguments()));
         }
         {
+            TestQuaExtract testQuaExtract;
+            err = qMax(err, QTest::qExec(&testQuaExtract, app.arguments()));
+        }
+        {
             TestQuaZipDir testQuaZipDir;
             err = qMax(err, QTest::qExec(&testQuaZipDir, app.arguments()));
         }

--- a/qztest/qztest.cpp
+++ b/qztest/qztest.cpp
@@ -297,65 +297,69 @@ int main(int argc, char **argv)
 {
     QCoreApplication app(argc, argv);
     int err = 0;
-    {
-        TestQuaZip testQuaZip;
-        err = qMax(err, QTest::qExec(&testQuaZip, app.arguments()));
-    }
-    {
-        TestQuaZipFile testQuaZipFile;
-        err = qMax(err, QTest::qExec(&testQuaZipFile, app.arguments()));
-    }
-    {
-        TestQuaChecksum32 testQuaChecksum32;
-        err = qMax(err, QTest::qExec(&testQuaChecksum32, app.arguments()));
-    }
-    {
-        TestJlCompress testJlCompress;
-        err = qMax(err, QTest::qExec(&testJlCompress, app.arguments()));
-    }
-    {
-        TestQuaCompress testQuaCompress;
-        err = qMax(err, QTest::qExec(&testQuaCompress, app.arguments()));
-    }
-    {
-        TestQuaZipDir testQuaZipDir;
-        err = qMax(err, QTest::qExec(&testQuaZipDir, app.arguments()));
-    }
-    {
-        TestQuaZIODevice testQuaZIODevice;
-        err = qMax(err, QTest::qExec(&testQuaZIODevice, app.arguments()));
-    }
-    {
-        TestQuaGzipFile testQuaGzipFile;
-        err = qMax(err, QTest::qExec(&testQuaGzipFile, app.arguments()));
-    }
-    {
-        TestQuaZipNewInfo testQuaZipNewInfo;
-        err = qMax(err, QTest::qExec(&testQuaZipNewInfo, app.arguments()));
-    }
-    {
-        TestQuaZipFileInfo testQuaZipFileInfo;
-        err = qMax(err, QTest::qExec(&testQuaZipFileInfo, app.arguments()));
-    }
+
     if (QString(qgetenv("TEST_CR_COMPRESS")) == "true")
     {
-      TestJlCpCompress testJlCpCompress;
-      err = qMax(err, QTest::qExec(&testJlCpCompress, app.arguments()));
+        TestJlCpCompress testJlCpCompress;
+        err = qMax(err, QTest::qExec(&testJlCpCompress, app.arguments()));
     }
-    if (QString(qgetenv("TEST_CR_DECOMPRESS")) == "true")
+    else if (QString(qgetenv("TEST_CR_DECOMPRESS")) == "true")
     {
-      TestJlCpExtract testJlCpExtract;
-      err = qMax(err, QTest::qExec(&testJlCpExtract, app.arguments()));
+        TestJlCpExtract testJlCpExtract;
+        err = qMax(err, QTest::qExec(&testJlCpExtract, app.arguments()));
     }
-    if (QString(qgetenv("TEST_UTF8_COMPRESS")) == "true")
+    else if (QString(qgetenv("TEST_UTF8_COMPRESS")) == "true")
     {
-      TestUtf8Compress testUtf8Compress;
-      err = qMax(err, QTest::qExec(&testUtf8Compress, app.arguments()));
+        TestUtf8Compress testUtf8Compress;
+        err = qMax(err, QTest::qExec(&testUtf8Compress, app.arguments()));
     }
-    if (QString(qgetenv("TEST_UTF8_DECOMPRESS")) == "true")
+    else if (QString(qgetenv("TEST_UTF8_DECOMPRESS")) == "true")
     {
-      TestUtf8Decompress testUtf8Decompress;
-      err = qMax(err, QTest::qExec(&testUtf8Decompress, app.arguments()));
+        TestUtf8Decompress testUtf8Decompress;
+        err = qMax(err, QTest::qExec(&testUtf8Decompress, app.arguments()));
+    }
+    else
+    {
+        {
+            TestQuaZip testQuaZip;
+            err = qMax(err, QTest::qExec(&testQuaZip, app.arguments()));
+        }
+        {
+            TestQuaZipFile testQuaZipFile;
+            err = qMax(err, QTest::qExec(&testQuaZipFile, app.arguments()));
+        }
+        {
+            TestQuaChecksum32 testQuaChecksum32;
+            err = qMax(err, QTest::qExec(&testQuaChecksum32, app.arguments()));
+        }
+        {
+            TestJlCompress testJlCompress;
+            err = qMax(err, QTest::qExec(&testJlCompress, app.arguments()));
+        }
+        {
+            TestQuaCompress testQuaCompress;
+            err = qMax(err, QTest::qExec(&testQuaCompress, app.arguments()));
+        }
+        {
+            TestQuaZipDir testQuaZipDir;
+            err = qMax(err, QTest::qExec(&testQuaZipDir, app.arguments()));
+        }
+        {
+            TestQuaZIODevice testQuaZIODevice;
+            err = qMax(err, QTest::qExec(&testQuaZIODevice, app.arguments()));
+        }
+        {
+            TestQuaGzipFile testQuaGzipFile;
+            err = qMax(err, QTest::qExec(&testQuaGzipFile, app.arguments()));
+        }
+        {
+            TestQuaZipNewInfo testQuaZipNewInfo;
+            err = qMax(err, QTest::qExec(&testQuaZipNewInfo, app.arguments()));
+        }
+        {
+            TestQuaZipFileInfo testQuaZipFileInfo;
+            err = qMax(err, QTest::qExec(&testQuaZipFileInfo, app.arguments()));
+        }
     }
 
     if (err == 0) {

--- a/qztest/qztest.h
+++ b/qztest/qztest.h
@@ -51,5 +51,6 @@ extern bool createTestArchive(QIODevice *ioDevice,
                               const QStringList &fileNames,
                               QuazipTextCodec *codec,
                               const QString &dir = "tmp");
+extern bool isPlatformUtf8();
 
 #endif // QUAZIP_TEST_QZTEST_H

--- a/qztest/testjlcompress.cpp
+++ b/qztest/testjlcompress.cpp
@@ -101,7 +101,7 @@ void TestJlCompress::compressFileOptions_data()
                             << "cb1847dff1a5c33a805efde2558fc74024ad4c64c8607f8b12903e4d92385955";
     QTest::newRow("simple-utf8") << "jlsimplefile-utf8.zip"
                             << QString::fromUtf8("ありがとう。.txt")
-                            << QDateTime(QDate(2024, 9, 19), QTime(21, 0, 0), QTimeZone::utc())
+                            << QDateTime(QDate(2024, 9, 19), QTime(21, 0, 0), COMPAT_UTC_TZ)
                             << JlCompress::Options::Default
                             << true
                             << QByteArray()
@@ -110,7 +110,7 @@ void TestJlCompress::compressFileOptions_data()
                             << "";
     QTest::newRow("simple-utf8-bad") << "jlsimplefile-utf8-bad.zip"
                                  << QString::fromUtf8("ありがとう。.txt")
-                                 << QDateTime(QDate(2024, 9, 19), QTime(21, 0, 0), QTimeZone::utc())
+                                 << QDateTime(QDate(2024, 9, 19), QTime(21, 0, 0), COMPAT_UTC_TZ)
                                  << JlCompress::Options::Default
                                  << false
                                  << QByteArray()

--- a/qztest/testjlcompress.cpp
+++ b/qztest/testjlcompress.cpp
@@ -112,11 +112,11 @@ void TestJlCompress::compressFileOptions_data()
                             << ""
                             << ""
                             << "";
-    QTest::newRow("simple-utf8-bad") << "jlsimplefile-utf8-bad.zip"
+    QTest::newRow("simple-utf8-no-flag") << "jlsimplefile-utf8-no-flag.zip"
                                  << QString::fromUtf8("ありがとう。.txt")
                                  << QDateTime(QDate(2024, 9, 19), QTime(21, 0, 0), COMPAT_UTC_TZ)
                                  << JlCompress::Options::Default
-                                 << false
+                                 << false  // UTF-8 flag disabled - tests compression without flag
                                  << QByteArray()
                                  << ""
                                  << ""
@@ -183,11 +183,8 @@ void TestJlCompress::compressFileOptions_data()
     // This means identical inputs produce different encrypted outputs each run.
     //
     // To make these deterministic (if needed in the future):
-    // - Would require modifying minizip vendor code (crypthead() in minizip_crypt.h)
+    // - Would require modifying minizip code (crypthead() in minizip_crypt.h)
     // - Add optional seed parameter through QuaZipFile → JlCompress → minizip layers
-    //
-    // Current approach: Test actual functionality (encryption/decryption works,
-    // wrong passwords fail) rather than implementation details (archive hash).
     QTest::newRow("password-simple") << "jlsimplefile-password.zip"
                                      << "test0.txt"
                                      << QDateTime(QDate(2024, 9, 19), QTime(21, 0, 0), COMPAT_UTC_TZ)
@@ -225,14 +222,6 @@ void TestJlCompress::compressFileOptions()
         QSKIP("Skipping UTF-8 test on non-UTF-8 platform");
     }
 
-#ifdef Q_OS_WIN
-    // Skip utf8-bad test on Windows - mangled filenames contain invalid characters
-    // (e.g., "??????.txt" where ? is not allowed in Windows filenames)
-    bool isUtf8BadTest = zipName == "jlsimplefile-utf8-bad.zip";
-    if (isUtf8BadTest && !isPlatformUtf8()) {
-        QSKIP("Skipping UTF-8-bad test on Windows non-UTF-8 - produces invalid filenames");
-    }
-#endif
 
     QDir curDir;
     if (curDir.exists(zipName)) {
@@ -246,21 +235,20 @@ void TestJlCompress::compressFileOptions()
     qDebug() << "Testing " << fileName;
 
     // Detect if platform defaults to UTF-8
-    bool platformIsUtf8 = false;
+    bool platformIsUtf8 = isPlatformUtf8();
     QString codecInfo;
 #ifdef QUAZIP_CAN_USE_QTEXTCODEC
     QTextCodec *defaultCodec = QTextCodec::codecForLocale();
     if (defaultCodec) {
-        QByteArray codecName = defaultCodec->name().toLower();
-        platformIsUtf8 = codecName.contains("utf-8") || codecName.contains("utf8");
         codecInfo = QString::fromLatin1(defaultCodec->name());
     }
 #else
-    // Qt6: check locale environment
-    QByteArray locale = qgetenv("LC_ALL");
-    if (locale.isEmpty()) locale = qgetenv("LANG");
-    platformIsUtf8 = locale.contains("UTF-8") || locale.contains("utf8");
-    codecInfo = QString::fromLatin1(locale);
+    // Qt 6: Platform-specific
+#ifdef Q_OS_WIN
+    codecInfo = "Windows (UTF-8 requires flag)";
+#else
+    codecInfo = "Qt6 (forces UTF-8)";
+#endif
 #endif
 
     JlCompress::Options options(dateTime, strategy, utf8, password);

--- a/qztest/testjlcompress.cpp
+++ b/qztest/testjlcompress.cpp
@@ -219,6 +219,12 @@ void TestJlCompress::compressFileOptions()
     QFETCH(QString, sha256sum_unix);
     QFETCH(QString, sha256sum_unix_ng);
     QFETCH(QString, sha256sum_win);
+
+    // Skip UTF-8 tests if platform doesn't support UTF-8
+    if (utf8 && !isPlatformUtf8()) {
+        QSKIP("Skipping UTF-8 test on non-UTF-8 platform");
+    }
+
     QDir curDir;
     if (curDir.exists(zipName)) {
       if (!curDir.remove(zipName))

--- a/qztest/testjlcompress.cpp
+++ b/qztest/testjlcompress.cpp
@@ -180,6 +180,8 @@ void TestJlCompress::compressFileOptions()
         QFAIL("Can't create test file");
     }
 
+    qDebug() << "Testing " << fileName;
+
     const JlCompress::Options options(dateTime, strategy, utf8);
     QVERIFY(JlCompress::compressFile(zipName, "tmp/" + fileName, options));
     // get the file list and check it

--- a/qztest/testjlcompress.cpp
+++ b/qztest/testjlcompress.cpp
@@ -232,21 +232,24 @@ void TestJlCompress::compressFileOptions()
 
     // Detect if platform defaults to UTF-8
     bool platformIsUtf8 = false;
+    QString codecInfo;
 #ifdef QUAZIP_CAN_USE_QTEXTCODEC
     QTextCodec *defaultCodec = QTextCodec::codecForLocale();
     if (defaultCodec) {
         QByteArray codecName = defaultCodec->name().toLower();
         platformIsUtf8 = codecName.contains("utf-8") || codecName.contains("utf8");
+        codecInfo = QString::fromLatin1(defaultCodec->name());
     }
 #else
     // Qt6: check locale environment
     QByteArray locale = qgetenv("LC_ALL");
     if (locale.isEmpty()) locale = qgetenv("LANG");
     platformIsUtf8 = locale.contains("UTF-8") || locale.contains("utf8");
+    codecInfo = QString::fromLatin1(locale);
 #endif
 
     if (!utf8) {
-        qDebug() << "Using default codec";
+        qDebug() << "Using default codec:" << codecInfo;
     } else {
         qDebug() << "Using UTF8";
     }

--- a/qztest/testjlcompress.cpp
+++ b/qztest/testjlcompress.cpp
@@ -34,6 +34,10 @@ see quazip/(un)zip.h files for details. Basically it's the zlib license.
 #include <QtCore/QCryptographicHash>
 #include <quazip_qt_compat.h>
 
+#ifdef QUAZIP_CAN_USE_QTEXTCODEC
+#include <QtCore/QTextCodec>
+#endif
+
 #include <QtTest/QTest>
 
 #include <JlCompress.h>
@@ -226,39 +230,56 @@ void TestJlCompress::compressFileOptions()
 
     qDebug() << "Testing " << fileName;
 
-    // For the "utf8-bad" test, temporarily set a non-UTF-8 locale
-    // to ensure the test actually produces different output from utf8-enabled version
-#ifndef Q_OS_WIN
-    QByteArray savedLocale;
-#endif
-    bool isUtf8BadTest = zipName == "jlsimplefile-utf8-bad.zip";
-    if (isUtf8BadTest) {
-#ifndef Q_OS_WIN
-        // On Unix/Linux, use LC_ALL environment variable
-        savedLocale = qgetenv("LC_ALL");
-        qputenv("LC_ALL", "C");  // Force POSIX/C locale
-#endif
+    // Detect if platform defaults to UTF-8
+    bool platformIsUtf8 = false;
 #ifdef QUAZIP_CAN_USE_QTEXTCODEC
-        // With QTextCodec, we can force a specific non-UTF-8 codec
-        QTextCodec::setCodecForLocale(QTextCodec::codecForName("ISO-8859-1"));
+    QTextCodec *defaultCodec = QTextCodec::codecForLocale();
+    if (defaultCodec) {
+        QByteArray codecName = defaultCodec->name().toLower();
+        platformIsUtf8 = codecName.contains("utf-8") || codecName.contains("utf8");
+    }
 #else
-        // With QStringConverter (fallback), LC_ALL=C should affect the "System" encoding
-        // but it's less reliable. The test may not work as intended without QTextCodec.
+    // Qt6: check locale environment
+    QByteArray locale = qgetenv("LC_ALL");
+    if (locale.isEmpty()) locale = qgetenv("LANG");
+    platformIsUtf8 = locale.contains("UTF-8") || locale.contains("utf8");
 #endif
+
+    if (!utf8) {
+        qDebug() << "Using default codec";
+    } else {
+        qDebug() << "Using UTF8";
     }
 
     JlCompress::Options options(dateTime, strategy, utf8, password);
     QVERIFY(JlCompress::compressFile(zipName, "tmp/" + fileName, options));
+
     // get the file list and check it
     QStringList fileList = JlCompress::getFileList(zipName);
     QCOMPARE(fileList.count(), 1);
-    QVERIFY(fileList[0] == fileName);
+
+    bool isUtf8BadTest = zipName == "jlsimplefile-utf8-bad.zip";
+    if (!utf8 && !platformIsUtf8) {
+        // On non-UTF-8 platforms without UTF-8 mode, filenames might be mangled
+        qDebug() << "Non-UTF-8 platform: expected mangled filename. Got:" << fileList[0] << "vs" << fileName;
+        // Just verify we got a filename, even if mangled
+        QVERIFY(!fileList[0].isEmpty());
+    } else {
+        QVERIFY(fileList[0] == fileName);
+    }
+
     // now test the QIODevice* overload of getFileList()
     QFile _zipFile(zipName);
     QVERIFY(_zipFile.open(QIODevice::ReadOnly));
     fileList = JlCompress::getFileList(zipName);
     QCOMPARE(fileList.count(), 1);
-    QVERIFY(fileList[0] == fileName);
+
+    if (!utf8 && !platformIsUtf8) {
+        // On non-UTF-8 platforms without UTF-8 mode, filenames might be mangled
+        QVERIFY(!fileList[0].isEmpty());
+    } else {
+        QVERIFY(fileList[0] == fileName);
+    }
     // Hash is computed on the resulting file externally, then hardcoded in the test data
     // This should help detecting any library breakage since we compare against a well-known stable result
     QString hash = QCryptographicHash::hash(_zipFile.readAll(), QCryptographicHash::Sha256).toHex();
@@ -280,39 +301,48 @@ void TestJlCompress::compressFileOptions()
 
     // Extract
     QString flist;
+    // On non-UTF-8 platforms without UTF-8 mode, use the mangled filename from the archive
+    QString extractName = (!utf8 && !platformIsUtf8) ? fileList[0] : fileName;
+
     if (!password.isEmpty()) {
         // Extract with password
-        flist = JlCompress::extractFile(zipName, fileName, QString(), password);
+        flist = JlCompress::extractFile(zipName, extractName, QString(), password);
         QFileInfo fileInfo(flist);
-        QVERIFY(fileInfo.fileName() == fileName);
+
+        if (!platformIsUtf8) {
+            // On non-UTF-8 platforms, filename might be mangled even with UTF-8 enabled
+            // because the locale codec can't represent the UTF-8 characters
+            qDebug() << "Expected mangled filename on non-UTF-8 platform:" << fileInfo.fileName() << "vs" << fileName;
+            // Just verify extraction succeeded
+            QVERIFY(!flist.isEmpty());
+        } else {
+            // On UTF-8 platforms, filename should match
+            QVERIFY(fileInfo.fileName() == fileName);
+        }
 
         // Test wrong password fails
-        QString wrongExtract = JlCompress::extractFile(zipName, fileName, "tmp/wrong_pw", QByteArray("wrongpassword"));
+        QString wrongExtract = JlCompress::extractFile(zipName, extractName, "tmp/wrong_pw", QByteArray("wrongpassword"));
         QVERIFY(wrongExtract.isEmpty());
     } else {
         // Extract without password
-        flist = JlCompress::extractFile(zipName, fileName);
+        flist = JlCompress::extractFile(zipName, extractName);
         QFileInfo fileInfo(flist);
-        QVERIFY(fileInfo.fileName() == fileName);
+
+        if (!platformIsUtf8) {
+            // On non-UTF-8 platforms, filename might be mangled even with UTF-8 enabled
+            // because the locale codec can't represent the UTF-8 characters
+            qDebug() << "Expected mangled filename on non-UTF-8 platform:" << fileInfo.fileName() << "vs" << fileName;
+            // Just verify extraction succeeded
+            QVERIFY(!flist.isEmpty());
+        } else {
+            // On UTF-8 platforms, filename should match
+            QVERIFY(fileInfo.fileName() == fileName);
+        }
     }
 
     removeTestFiles(QStringList() << fileName << flist);
     curDir.remove(zipName);
 
-    // Restore locale if we changed it
-    if (isUtf8BadTest) {
-#ifndef Q_OS_WIN
-        // Restore LC_ALL on Unix/Linux
-        if (savedLocale.isEmpty()) {
-            qunsetenv("LC_ALL");
-        } else {
-            qputenv("LC_ALL", savedLocale);
-        }
-#endif
-#ifdef QUAZIP_CAN_USE_QTEXTCODEC
-        QTextCodec::setCodecForLocale(nullptr);  // Reset to default
-#endif
-    }
 }
 
 void TestJlCompress::compressFiles_data()

--- a/qztest/testjlcompress.cpp
+++ b/qztest/testjlcompress.cpp
@@ -254,12 +254,6 @@ void TestJlCompress::compressFileOptions()
     codecInfo = QString::fromLatin1(locale);
 #endif
 
-    if (!utf8) {
-        qDebug() << "Using default codec:" << codecInfo;
-    } else {
-        qDebug() << "Using UTF8";
-    }
-
     JlCompress::Options options(dateTime, strategy, utf8, password);
     QVERIFY(JlCompress::compressFile(zipName, "tmp/" + fileName, options));
 
@@ -270,7 +264,6 @@ void TestJlCompress::compressFileOptions()
     bool isUtf8BadTest = zipName == "jlsimplefile-utf8-bad.zip";
     if (!utf8 && !platformIsUtf8) {
         // On non-UTF-8 platforms without UTF-8 mode, filenames might be mangled
-        qDebug() << "Non-UTF-8 platform: expected mangled filename. Got:" << fileList[0] << "vs" << fileName;
         // Just verify we got a filename, even if mangled
         QVERIFY(!fileList[0].isEmpty());
     } else {
@@ -321,7 +314,6 @@ void TestJlCompress::compressFileOptions()
         if (!platformIsUtf8) {
             // On non-UTF-8 platforms, filename might be mangled even with UTF-8 enabled
             // because the locale codec can't represent the UTF-8 characters
-            qDebug() << "Expected mangled filename on non-UTF-8 platform:" << fileInfo.fileName() << "vs" << fileName;
             // Just verify extraction succeeded
             QVERIFY(!flist.isEmpty());
         } else {
@@ -340,7 +332,6 @@ void TestJlCompress::compressFileOptions()
         if (!platformIsUtf8) {
             // On non-UTF-8 platforms, filename might be mangled even with UTF-8 enabled
             // because the locale codec can't represent the UTF-8 characters
-            qDebug() << "Expected mangled filename on non-UTF-8 platform:" << fileInfo.fileName() << "vs" << fileName;
             // Just verify extraction succeeded
             QVERIFY(!flist.isEmpty());
         } else {

--- a/qztest/testjlcompress.cpp
+++ b/qztest/testjlcompress.cpp
@@ -35,7 +35,7 @@ see quazip/(un)zip.h files for details. Basically it's the zlib license.
 #include <quazip_qt_compat.h>
 
 #ifdef QUAZIP_CAN_USE_QTEXTCODEC
-#include <QtCore/QTextCodec>
+#include <QTextCodec>
 #endif
 
 #include <QtTest/QTest>

--- a/qztest/testjlcompress.cpp
+++ b/qztest/testjlcompress.cpp
@@ -86,6 +86,7 @@ void TestJlCompress::compressFileOptions_data()
     QTest::addColumn<QDateTime>("dateTime");
     QTest::addColumn<JlCompress::Options::CompressionStrategy>("strategy");
     QTest::addColumn<bool>("utf8");
+    QTest::addColumn<QByteArray>("password");
     QTest::addColumn<QString>("sha256sum_unix"); // Due to extra data archives are not identical
     QTest::addColumn<QString>("sha256sum_unix_ng"); // zlib-ng
     QTest::addColumn<QString>("sha256sum_win");
@@ -94,6 +95,7 @@ void TestJlCompress::compressFileOptions_data()
                             << QDateTime(QDate(2024, 9, 19), QTime(21, 0, 0), COMPAT_UTC_TZ)
                             << JlCompress::Options::Default
                             << false
+                            << QByteArray()
                             << "5eedd83aee92cf3381155d167fee54a4ef6e43b8bc7a979c903611d9aa28610a"
                             << "752db50b15db1a19e091f9c1b43ec22b279867b20d43c76bc9a01d7bc0d7ae4f"
                             << "cb1847dff1a5c33a805efde2558fc74024ad4c64c8607f8b12903e4d92385955";
@@ -102,6 +104,8 @@ void TestJlCompress::compressFileOptions_data()
                             << QDateTime(QDate(2024, 9, 19), QTime(21, 0, 0), QTimeZone::utc())
                             << JlCompress::Options::Default
                             << true
+                            << QByteArray()
+                            << ""
                             << ""
                             << "";
     QTest::newRow("simple-utf8-bad") << "jlsimplefile-utf8-bad.zip"
@@ -109,6 +113,8 @@ void TestJlCompress::compressFileOptions_data()
                                  << QDateTime(QDate(2024, 9, 19), QTime(21, 0, 0), QTimeZone::utc())
                                  << JlCompress::Options::Default
                                  << false
+                                 << QByteArray()
+                                 << ""
                                  << ""
                                  << "";
     QTest::newRow("simple-storage") << "jlsimplefile-storage.zip"
@@ -116,6 +122,7 @@ void TestJlCompress::compressFileOptions_data()
                                     << QDateTime(QDate(2024, 9, 19), QTime(21, 0, 0), COMPAT_UTC_TZ)
                                     << JlCompress::Options::Storage
                                     << false
+                                    << QByteArray()
                                     << ""
                                     << ""
                                     << "";
@@ -124,6 +131,7 @@ void TestJlCompress::compressFileOptions_data()
                                     << QDateTime(QDate(2024, 9, 19), QTime(21, 0, 0), COMPAT_UTC_TZ)
                                     << JlCompress::Options::Fastest
                                     << false
+                                    << QByteArray()
                                     << ""
                                     << ""
                                     << "";
@@ -132,6 +140,7 @@ void TestJlCompress::compressFileOptions_data()
                                    << QDateTime(QDate(2024, 9, 19), QTime(21, 0, 0), COMPAT_UTC_TZ)
                                    << JlCompress::Options::Faster
                                    << false
+                                   << QByteArray()
                                    << ""
                                    << ""
                                    << "";
@@ -140,6 +149,7 @@ void TestJlCompress::compressFileOptions_data()
                                      << QDateTime(QDate(2024, 9, 19), QTime(21, 0, 0), COMPAT_UTC_TZ)
                                      << JlCompress::Options::Standard
                                      << false
+                                     << QByteArray()
                                      << "5eedd83aee92cf3381155d167fee54a4ef6e43b8bc7a979c903611d9aa28610a"
                                      << "752db50b15db1a19e091f9c1b43ec22b279867b20d43c76bc9a01d7bc0d7ae4f"
                                      << "cb1847dff1a5c33a805efde2558fc74024ad4c64c8607f8b12903e4d92385955";
@@ -148,6 +158,7 @@ void TestJlCompress::compressFileOptions_data()
                                    << QDateTime(QDate(2024, 9, 19), QTime(21, 0, 0), COMPAT_UTC_TZ)
                                    << JlCompress::Options::Better
                                    << false
+                                   << QByteArray()
                                    << ""
                                    << ""
                                    << "";
@@ -156,9 +167,41 @@ void TestJlCompress::compressFileOptions_data()
                                  << QDateTime(QDate(2024, 9, 19), QTime(21, 0, 0), COMPAT_UTC_TZ)
                                  << JlCompress::Options::Best
                                  << false
+                                 << QByteArray()
                                  << ""
                                  << ""
                                  << "";
+    // Password tests - SHA256 validation is skipped (empty strings) because
+    // encrypted ZIP archives are NOT deterministic:
+    //
+    // Traditional PKWARE Encryption (ZipCrypto) generates a 12-byte random header
+    // for each file using srand(time(NULL) ^ ZCR_SEED2) in minizip_crypt.h.
+    // This means identical inputs produce different encrypted outputs each run.
+    //
+    // To make these deterministic (if needed in the future):
+    // - Would require modifying minizip vendor code (crypthead() in minizip_crypt.h)
+    // - Add optional seed parameter through QuaZipFile → JlCompress → minizip layers
+    //
+    // Current approach: Test actual functionality (encryption/decryption works,
+    // wrong passwords fail) rather than implementation details (archive hash).
+    QTest::newRow("password-simple") << "jlsimplefile-password.zip"
+                                     << "test0.txt"
+                                     << QDateTime(QDate(2024, 9, 19), QTime(21, 0, 0), COMPAT_UTC_TZ)
+                                     << JlCompress::Options::Default
+                                     << false
+                                     << QByteArray("password123")
+                                     << ""
+                                     << ""
+                                     << "";
+    QTest::newRow("password-utf8") << "jlsimplefile-password-utf8.zip"
+                                   << QString::fromUtf8("файл.txt")
+                                   << QDateTime(QDate(2024, 9, 19), QTime(21, 0, 0), COMPAT_UTC_TZ)
+                                   << JlCompress::Options::Best
+                                   << true
+                                   << QByteArray("секрет")
+                                   << ""
+                                   << ""
+                                   << "";
 }
 
 void TestJlCompress::compressFileOptions()
@@ -168,6 +211,7 @@ void TestJlCompress::compressFileOptions()
     QFETCH(QDateTime, dateTime);
     QFETCH(JlCompress::Options::CompressionStrategy, strategy);
     QFETCH(bool, utf8);
+    QFETCH(QByteArray, password);
     QFETCH(QString, sha256sum_unix);
     QFETCH(QString, sha256sum_unix_ng);
     QFETCH(QString, sha256sum_win);
@@ -182,7 +226,28 @@ void TestJlCompress::compressFileOptions()
 
     qDebug() << "Testing " << fileName;
 
-    const JlCompress::Options options(dateTime, strategy, utf8);
+    // For the "utf8-bad" test, temporarily set a non-UTF-8 locale
+    // to ensure the test actually produces different output from utf8-enabled version
+#ifndef Q_OS_WIN
+    QByteArray savedLocale;
+#endif
+    bool isUtf8BadTest = zipName == "jlsimplefile-utf8-bad.zip";
+    if (isUtf8BadTest) {
+#ifndef Q_OS_WIN
+        // On Unix/Linux, use LC_ALL environment variable
+        savedLocale = qgetenv("LC_ALL");
+        qputenv("LC_ALL", "C");  // Force POSIX/C locale
+#endif
+#ifdef QUAZIP_CAN_USE_QTEXTCODEC
+        // With QTextCodec, we can force a specific non-UTF-8 codec
+        QTextCodec::setCodecForLocale(QTextCodec::codecForName("ISO-8859-1"));
+#else
+        // With QStringConverter (fallback), LC_ALL=C should affect the "System" encoding
+        // but it's less reliable. The test may not work as intended without QTextCodec.
+#endif
+    }
+
+    JlCompress::Options options(dateTime, strategy, utf8, password);
     QVERIFY(JlCompress::compressFile(zipName, "tmp/" + fileName, options));
     // get the file list and check it
     QStringList fileList = JlCompress::getFileList(zipName);
@@ -198,22 +263,56 @@ void TestJlCompress::compressFileOptions()
     // This should help detecting any library breakage since we compare against a well-known stable result
     QString hash = QCryptographicHash::hash(_zipFile.readAll(), QCryptographicHash::Sha256).toHex();
 #if defined Q_OS_WIN
-    if (!sha256sum_win.isEmpty()) QCOMPARE(hash, sha256sum_win);
+    if (!sha256sum_win.isEmpty()) {
+        QCOMPARE(hash, sha256sum_win);
+    }
 #elif defined ZLIBNG_VERSION
-    if (!sha256sum_unix_ng.isEmpty()) QCOMPARE(hash, sha256sum_unix_ng);
+    if (!sha256sum_unix_ng.isEmpty()) {
+        QCOMPARE(hash, sha256sum_unix_ng);
+    }
 #else
-    if (!sha256sum_unix.isEmpty()) QCOMPARE(hash, sha256sum_unix);
+    if (!sha256sum_unix.isEmpty()) {
+        QCOMPARE(hash, sha256sum_unix);
+    }
 #endif
 
     _zipFile.close();
 
     // Extract
-    QString flist = JlCompress::extractFile(zipName, fileName);
-    QFileInfo fileInfo(flist);
-    QVERIFY(fileInfo.fileName() == fileName);
+    QString flist;
+    if (!password.isEmpty()) {
+        // Extract with password
+        flist = JlCompress::extractFile(zipName, fileName, QString(), password);
+        QFileInfo fileInfo(flist);
+        QVERIFY(fileInfo.fileName() == fileName);
+
+        // Test wrong password fails
+        QString wrongExtract = JlCompress::extractFile(zipName, fileName, "tmp/wrong_pw", QByteArray("wrongpassword"));
+        QVERIFY(wrongExtract.isEmpty());
+    } else {
+        // Extract without password
+        flist = JlCompress::extractFile(zipName, fileName);
+        QFileInfo fileInfo(flist);
+        QVERIFY(fileInfo.fileName() == fileName);
+    }
 
     removeTestFiles(QStringList() << fileName << flist);
     curDir.remove(zipName);
+
+    // Restore locale if we changed it
+    if (isUtf8BadTest) {
+#ifndef Q_OS_WIN
+        // Restore LC_ALL on Unix/Linux
+        if (savedLocale.isEmpty()) {
+            qunsetenv("LC_ALL");
+        } else {
+            qputenv("LC_ALL", savedLocale);
+        }
+#endif
+#ifdef QUAZIP_CAN_USE_QTEXTCODEC
+        QTextCodec::setCodecForLocale(nullptr);  // Reset to default
+#endif
+    }
 }
 
 void TestJlCompress::compressFiles_data()

--- a/qztest/testjlcompress.cpp
+++ b/qztest/testjlcompress.cpp
@@ -225,6 +225,15 @@ void TestJlCompress::compressFileOptions()
         QSKIP("Skipping UTF-8 test on non-UTF-8 platform");
     }
 
+#ifdef Q_OS_WIN
+    // Skip utf8-bad test on Windows - mangled filenames contain invalid characters
+    // (e.g., "??????.txt" where ? is not allowed in Windows filenames)
+    bool isUtf8BadTest = zipName == "jlsimplefile-utf8-bad.zip";
+    if (isUtf8BadTest && !isPlatformUtf8()) {
+        QSKIP("Skipping UTF-8-bad test on Windows non-UTF-8 - produces invalid filenames");
+    }
+#endif
+
     QDir curDir;
     if (curDir.exists(zipName)) {
       if (!curDir.remove(zipName))
@@ -261,7 +270,6 @@ void TestJlCompress::compressFileOptions()
     QStringList fileList = JlCompress::getFileList(zipName);
     QCOMPARE(fileList.count(), 1);
 
-    bool isUtf8BadTest = zipName == "jlsimplefile-utf8-bad.zip";
     if (!utf8 && !platformIsUtf8) {
         // On non-UTF-8 platforms without UTF-8 mode, filenames might be mangled
         // Just verify we got a filename, even if mangled

--- a/qztest/testjlcompress.cpp
+++ b/qztest/testjlcompress.cpp
@@ -85,6 +85,7 @@ void TestJlCompress::compressFileOptions_data()
     QTest::addColumn<QString>("fileName");
     QTest::addColumn<QDateTime>("dateTime");
     QTest::addColumn<JlCompress::Options::CompressionStrategy>("strategy");
+    QTest::addColumn<bool>("utf8");
     QTest::addColumn<QString>("sha256sum_unix"); // Due to extra data archives are not identical
     QTest::addColumn<QString>("sha256sum_unix_ng"); // zlib-ng
     QTest::addColumn<QString>("sha256sum_win");
@@ -92,13 +93,29 @@ void TestJlCompress::compressFileOptions_data()
                             << "test0.txt"
                             << QDateTime(QDate(2024, 9, 19), QTime(21, 0, 0), COMPAT_UTC_TZ)
                             << JlCompress::Options::Default
+                            << false
                             << "5eedd83aee92cf3381155d167fee54a4ef6e43b8bc7a979c903611d9aa28610a"
                             << "752db50b15db1a19e091f9c1b43ec22b279867b20d43c76bc9a01d7bc0d7ae4f"
                             << "cb1847dff1a5c33a805efde2558fc74024ad4c64c8607f8b12903e4d92385955";
+    QTest::newRow("simple-utf8") << "jlsimplefile-utf8.zip"
+                            << QString::fromUtf8("ありがとう。.txt")
+                            << QDateTime(QDate(2024, 9, 19), QTime(21, 0, 0), QTimeZone::utc())
+                            << JlCompress::Options::Default
+                            << true
+                            << ""
+                            << "";
+    QTest::newRow("simple-utf8-bad") << "jlsimplefile-utf8-bad.zip"
+                                 << QString::fromUtf8("ありがとう。.txt")
+                                 << QDateTime(QDate(2024, 9, 19), QTime(21, 0, 0), QTimeZone::utc())
+                                 << JlCompress::Options::Default
+                                 << false
+                                 << ""
+                                 << "";
     QTest::newRow("simple-storage") << "jlsimplefile-storage.zip"
                                     << "test0.txt"
                                     << QDateTime(QDate(2024, 9, 19), QTime(21, 0, 0), COMPAT_UTC_TZ)
                                     << JlCompress::Options::Storage
+                                    << false
                                     << ""
                                     << ""
                                     << "";
@@ -106,6 +123,7 @@ void TestJlCompress::compressFileOptions_data()
                                     << "test0.txt"
                                     << QDateTime(QDate(2024, 9, 19), QTime(21, 0, 0), COMPAT_UTC_TZ)
                                     << JlCompress::Options::Fastest
+                                    << false
                                     << ""
                                     << ""
                                     << "";
@@ -113,6 +131,7 @@ void TestJlCompress::compressFileOptions_data()
                                    << "test0.txt"
                                    << QDateTime(QDate(2024, 9, 19), QTime(21, 0, 0), COMPAT_UTC_TZ)
                                    << JlCompress::Options::Faster
+                                   << false
                                    << ""
                                    << ""
                                    << "";
@@ -120,6 +139,7 @@ void TestJlCompress::compressFileOptions_data()
                                      << "test0.txt"
                                      << QDateTime(QDate(2024, 9, 19), QTime(21, 0, 0), COMPAT_UTC_TZ)
                                      << JlCompress::Options::Standard
+                                     << false
                                      << "5eedd83aee92cf3381155d167fee54a4ef6e43b8bc7a979c903611d9aa28610a"
                                      << "752db50b15db1a19e091f9c1b43ec22b279867b20d43c76bc9a01d7bc0d7ae4f"
                                      << "cb1847dff1a5c33a805efde2558fc74024ad4c64c8607f8b12903e4d92385955";
@@ -127,6 +147,7 @@ void TestJlCompress::compressFileOptions_data()
                                    << "test0.txt"
                                    << QDateTime(QDate(2024, 9, 19), QTime(21, 0, 0), COMPAT_UTC_TZ)
                                    << JlCompress::Options::Better
+                                   << false
                                    << ""
                                    << ""
                                    << "";
@@ -134,6 +155,7 @@ void TestJlCompress::compressFileOptions_data()
                                  << "test0.txt"
                                  << QDateTime(QDate(2024, 9, 19), QTime(21, 0, 0), COMPAT_UTC_TZ)
                                  << JlCompress::Options::Best
+                                 << false
                                  << ""
                                  << ""
                                  << "";
@@ -145,6 +167,7 @@ void TestJlCompress::compressFileOptions()
     QFETCH(QString, fileName);
     QFETCH(QDateTime, dateTime);
     QFETCH(JlCompress::Options::CompressionStrategy, strategy);
+    QFETCH(bool, utf8);
     QFETCH(QString, sha256sum_unix);
     QFETCH(QString, sha256sum_unix_ng);
     QFETCH(QString, sha256sum_win);
@@ -157,7 +180,7 @@ void TestJlCompress::compressFileOptions()
         QFAIL("Can't create test file");
     }
 
-    const JlCompress::Options options(dateTime, strategy);
+    const JlCompress::Options options(dateTime, strategy, utf8);
     QVERIFY(JlCompress::compressFile(zipName, "tmp/" + fileName, options));
     // get the file list and check it
     QStringList fileList = JlCompress::getFileList(zipName);
@@ -179,8 +202,15 @@ void TestJlCompress::compressFileOptions()
 #else
     if (!sha256sum_unix.isEmpty()) QCOMPARE(hash, sha256sum_unix);
 #endif
+
     _zipFile.close();
-    removeTestFiles(QStringList() << fileName);
+
+    // Extract
+    QString flist = JlCompress::extractFile(zipName, fileName);
+    QFileInfo fileInfo(flist);
+    QVERIFY(fileInfo.fileName() == fileName);
+
+    removeTestFiles(QStringList() << fileName << flist);
     curDir.remove(zipName);
 }
 

--- a/qztest/testjlcompress.cpp
+++ b/qztest/testjlcompress.cpp
@@ -222,6 +222,12 @@ void TestJlCompress::compressFileOptions()
         QSKIP("Skipping UTF-8 test on non-UTF-8 platform");
     }
 
+    // Skip tests with non-ASCII filenames on non-UTF-8 platforms
+    // Windows filesystem will mangle UTF-8 filenames to '??????' during file creation
+    if (!isPlatformUtf8() && fileName.toUtf8() != fileName.toLatin1()) {
+        QSKIP("Skipping test with non-ASCII filename on non-UTF-8 platform");
+    }
+
 
     QDir curDir;
     if (curDir.exists(zipName)) {

--- a/qztest/testjlcp_compress.cpp
+++ b/qztest/testjlcp_compress.cpp
@@ -46,15 +46,30 @@ void TestJlCpCompress::compressFileOptions_data()
     QTest::addColumn<QString>("zipName");
     QTest::addColumn<QString>("fileName");
     QTest::addColumn<JlCompress::Options::CompressionStrategy>("strategy");
+    QTest::addColumn<QByteArray>("password");
+
     QTest::newRow("simple") << "jlsimplefile.zip"
                             << "test0.txt"
-                            << JlCompress::Options::Default;
+                            << JlCompress::Options::Default
+                            << QByteArray();
     QTest::newRow("simple-storage") << "jlsimplefile-storage.zip"
                                     << "test0.txt"
-                                    << JlCompress::Options::Storage;
+                                    << JlCompress::Options::Storage
+                                    << QByteArray();
     QTest::newRow("simple-best") << "jlsimplefile-best.zip"
                                  << "test0.txt"
-                                 << JlCompress::Options::Best;
+                                 << JlCompress::Options::Best
+                                 << QByteArray();
+
+    // Encrypted archives - test cross-platform encryption compatibility
+    QTest::newRow("encrypted-default") << "jlsimplefile-encrypted.zip"
+                                       << "test0.txt"
+                                       << JlCompress::Options::Default
+                                       << QByteArray("testpassword");
+    QTest::newRow("encrypted-best") << "jlsimplefile-encrypted-best.zip"
+                                    << "test0.txt"
+                                    << JlCompress::Options::Best
+                                    << QByteArray("testpassword");
 }
 
 void TestJlCpCompress::compressFileOptions()
@@ -62,6 +77,8 @@ void TestJlCpCompress::compressFileOptions()
     QFETCH(QString, zipName);
     QFETCH(QString, fileName);
     QFETCH(JlCompress::Options::CompressionStrategy, strategy);
+    QFETCH(QByteArray, password);
+
     QDir curDir;
     if (curDir.exists(zipName)) {
       if (!curDir.remove(zipName))
@@ -71,7 +88,7 @@ void TestJlCpCompress::compressFileOptions()
         QFAIL("Can't create test file");
     }
 
-    const JlCompress::Options options(strategy);
+    const JlCompress::Options options(QDateTime(), strategy, false, password);
     QVERIFY(JlCompress::compressFile(zipName, "tmp/" + fileName, options));
 
     removeTestFiles(QStringList() << fileName);

--- a/qztest/testjlcp_extract.cpp
+++ b/qztest/testjlcp_extract.cpp
@@ -53,7 +53,15 @@ void TestJlCpExtract::extract()
 	QSet<QString> zipNames = {
 	  "jlsimplefile.zip",
 	  "jlsimplefile-storage.zip",
-	  "jlsimplefile-best.zip"
+	  "jlsimplefile-best.zip",
+	  "jlsimplefile-encrypted.zip",
+	  "jlsimplefile-encrypted-best.zip"
+	};
+
+	// Map of encrypted archives to their passwords
+	QMap<QString, QByteArray> passwordMap = {
+	  {"jlsimplefile-encrypted.zip", QByteArray("testpassword")},
+	  {"jlsimplefile-encrypted-best.zip", QByteArray("testpassword")}
 	};
 
     QSet<QString> fileNames = {
@@ -84,17 +92,25 @@ void TestJlCpExtract::extract()
         QVERIFY(extractedZipSet.isEmpty());
 
         for (const QString &_zipFile : zipNames) {
-        	qDebug() << "Found ZIP:" << _zipFile;
+            qDebug() << "Found ZIP:" << _zipFile;
             QFileInfo zip(target2, _zipFile);
-			QDir target3(target2.absolutePath()+"/"+zip.completeBaseName());
+	    QDir target3(target2.absolutePath()+"/"+zip.completeBaseName());
             // macos-13_qt6.8.2_sharedON_cp/cp/jlsimplefile/
-			JlCompress::extractDir(zip.absoluteFilePath(), target3.absolutePath());
 
-			QList<QString> extractedFileList = target3.entryList(QDir::Files);
-			QSet<QString> extractedFileSet(extractedFileList.begin(), extractedFileList.end());
+	    // Extract with password if this is an encrypted archive
+	    QStringList extracted;
+	    if (passwordMap.contains(_zipFile)) {
+	        extracted = JlCompress::extractDir(zip.absoluteFilePath(), target3.absolutePath(), passwordMap[_zipFile]);
+	    } else {
+	        extracted = JlCompress::extractDir(zip.absoluteFilePath(), target3.absolutePath());
+	    }
+	    QVERIFY(!extracted.isEmpty());
+
+	    QList<QString> extractedFileList = target3.entryList(QDir::Files);
+	    QSet<QString> extractedFileSet(extractedFileList.begin(), extractedFileList.end());
 
             extractedFileSet = extractedFileSet.subtract(fileNames);
-			QVERIFY(extractedFileSet.isEmpty());
+            QVERIFY(extractedFileSet.isEmpty());
 
             // Check file content
             for (const QString &fileName : extractedFileList) {
@@ -116,5 +132,5 @@ void TestJlCpExtract::extract()
                 QVERIFY(fileContent == expectedContent);
             }
         }
-	}
+    }
 }

--- a/qztest/testquacompress.cpp
+++ b/qztest/testquacompress.cpp
@@ -29,51 +29,11 @@ See COPYING file for the full LGPL text.
 #include <QtTest/QTest>
 
 #include <QuaCompress.h>
+#include <QuaExtract.h>
 
-Q_DECLARE_METATYPE(JlCompress::Options::CompressionStrategy)
+Q_DECLARE_METATYPE(QuaCompress::CompressionStrategy)
 
-// Test data for fluent API chaining
-void TestQuaCompress::fluentApiChaining_data()
-{
-    QTest::addColumn<QString>("zipName");
-    QTest::addColumn<QString>("fileName");
-
-    QTest::newRow("simple") << "quacompress_chain.zip" << "test0.txt";
-}
-
-// Test that fluent API chaining works correctly
-void TestQuaCompress::fluentApiChaining()
-{
-    QFETCH(QString, zipName);
-    QFETCH(QString, fileName);
-
-    // Create test file
-    QVERIFY(createTestFiles(QStringList() << fileName));
-
-    // Test method chaining returns reference to same object
-    QuaCompress compressor;
-    QuaCompress& ref1 = compressor.withUtf8Enabled(true);
-    QCOMPARE(&ref1, &compressor);
-
-    QuaCompress& ref2 = compressor.withCompression(JlCompress::Options::Better);
-    QCOMPARE(&ref2, &compressor);
-
-    QuaCompress& ref3 = compressor.withDateTime(QDateTime::currentDateTime());
-    QCOMPARE(&ref3, &compressor);
-
-    // Test that chained configuration works end-to-end
-    bool result = QuaCompress()
-        .withUtf8Enabled()
-        .withCompression(JlCompress::Options::Best)
-        .compressFile(zipName, "tmp/" + fileName);
-
-    QVERIFY(result);
-    QVERIFY(QFile::exists(zipName));
-
-    // Cleanup
-    removeTestFiles(QStringList() << fileName);
-    QFile::remove(zipName);
-}
+// ==================== TestQuaCompress ====================
 
 // Test data for compressFile - comprehensive matrix of options
 void TestQuaCompress::compressFile_data()
@@ -81,58 +41,58 @@ void TestQuaCompress::compressFile_data()
     QTest::addColumn<QString>("zipName");
     QTest::addColumn<QString>("fileName");
     QTest::addColumn<bool>("utf8");
-    QTest::addColumn<JlCompress::Options::CompressionStrategy>("compression");
+    QTest::addColumn<QuaCompress::CompressionStrategy>("compression");
     QTest::addColumn<QByteArray>("password");
 
     // Basic tests with different compression levels
     QTest::newRow("simple") << "quacompress_simple.zip"
                             << "test0.txt"
                             << false
-                            << JlCompress::Options::Default
+                            << QuaCompress::Default
                             << QByteArray();
     QTest::newRow("storage") << "quacompress_storage.zip"
                              << "test0.txt"
                              << false
-                             << JlCompress::Options::Storage
+                             << QuaCompress::Storage
                              << QByteArray();
     QTest::newRow("fastest") << "quacompress_fastest.zip"
                              << "test0.txt"
                              << false
-                             << JlCompress::Options::Fastest
+                             << QuaCompress::Fastest
                              << QByteArray();
     QTest::newRow("best") << "quacompress_best.zip"
                           << "test0.txt"
                           << false
-                          << JlCompress::Options::Best
+                          << QuaCompress::Best
                           << QByteArray();
 
     // UTF-8 tests with different scripts and compression levels
     QTest::newRow("utf8-japanese-best") << "quacompress_utf8_ja.zip"
                                         << QString::fromUtf8("ありがとう.txt")
                                         << true
-                                        << JlCompress::Options::Best
+                                        << QuaCompress::Best
                           << QByteArray();
     QTest::newRow("utf8-cyrillic-default") << "quacompress_utf8_ru.zip"
                                            << QString::fromUtf8("Привет.txt")
                                            << true
-                                           << JlCompress::Options::Default
+                                           << QuaCompress::Default
                                            << QByteArray();
     QTest::newRow("utf8-chinese-fastest") << "quacompress_utf8_zh.zip"
                                           << QString::fromUtf8("你好.txt")
                                           << true
-                                          << JlCompress::Options::Fastest
+                                          << QuaCompress::Fastest
                              << QByteArray();
 
     // Password tests
     QTest::newRow("password-simple") << "quacompress_password.zip"
                                      << "test0.txt"
                                      << false
-                                     << JlCompress::Options::Default
+                                     << QuaCompress::Default
                                      << QByteArray("password123");
     QTest::newRow("password-utf8-best") << "quacompress_password_utf8.zip"
                                         << QString::fromUtf8("тест.txt")
                                         << true
-                                        << JlCompress::Options::Best
+                                        << QuaCompress::Best
                                         << QByteArray("секрет");
 }
 
@@ -142,7 +102,7 @@ void TestQuaCompress::compressFile()
     QFETCH(QString, zipName);
     QFETCH(QString, fileName);
     QFETCH(bool, utf8);
-    QFETCH(JlCompress::Options::CompressionStrategy, compression);
+    QFETCH(QuaCompress::CompressionStrategy, compression);
     QFETCH(QByteArray, password);
 
     // Skip UTF-8 tests if platform doesn't support UTF-8
@@ -162,14 +122,14 @@ void TestQuaCompress::compressFile()
     // Compress file (fluent API)
     bool result = QuaCompress()
         .withUtf8Enabled(utf8)
-        .withCompression(compression)
+        .withStrategy(compression)
         .withPassword(password)
         .compressFile(zipName, "tmp/" + fileName);
     QVERIFY(result);
     QVERIFY(QFile::exists(zipName));
 
     // Verify file list (works without password)
-    QStringList fileList = QuaCompress().getFileList(zipName);
+    QStringList fileList = QuaExtract().getFileList(zipName);
     QCOMPARE(fileList.count(), 1);
     QCOMPARE(fileList[0], fileName);
 
@@ -177,21 +137,21 @@ void TestQuaCompress::compressFile()
     QStringList extracted;
     if (!password.isEmpty()) {
         // Test fluent API extraction
-        extracted = QuaCompress()
+        extracted = QuaExtract()
             .withPassword(password)
             .extractDir(zipName, "tmp/quacompress_extracted");
         QCOMPARE(extracted.size(), 1);
         QVERIFY(QFile::exists("tmp/quacompress_extracted/" + fileName));
 
         // Test wrong password fails
-        QStringList wrongExtract = QuaCompress()
+        QStringList wrongExtract = QuaExtract()
             .withPassword(QByteArray("wrong"))
             .extractDir(zipName, "tmp/quacompress_wrong");
         QCOMPARE(wrongExtract.size(), 0);
         QDir("tmp/quacompress_wrong").removeRecursively();
     } else {
         // No password
-        extracted = QuaCompress().extractDir(zipName, "tmp/quacompress_extracted");
+        extracted = QuaExtract().extractDir(zipName, "tmp/quacompress_extracted");
         QCOMPARE(extracted.size(), 1);
         QVERIFY(QFile::exists("tmp/quacompress_extracted/" + fileName));
     }
@@ -255,7 +215,7 @@ void TestQuaCompress::compressFiles()
     QVERIFY(result);
 
     // Verify file list
-    QStringList list = QuaCompress().getFileList(zipName);
+    QStringList list = QuaExtract().getFileList(zipName);
     QCOMPARE(list, shortNamesList);
 
     // Cleanup
@@ -320,64 +280,12 @@ void TestQuaCompress::compressDir()
     QVERIFY(result);
 
     // Verify file list has at least the expected number of files
-    QStringList list = QuaCompress().getFileList(zipName);
+    QStringList list = QuaExtract().getFileList(zipName);
     QVERIFY(list.size() >= expectedMinFiles);
 
     // Cleanup
     removeTestFiles(fileNames);
     curDir.remove(zipName);
-}
-
-// Test data for extractDir
-void TestQuaCompress::extractDir_data()
-{
-    QTest::addColumn<QString>("zipName");
-    QTest::addColumn<QStringList>("fileNames");
-    QTest::addColumn<QString>("extractDir");
-
-    QTest::newRow("simple") << "quacompress_extract.zip"
-                            << (QStringList() << "test0.txt" << "test1.txt")
-                            << "tmp/quacompress_ext/";
-    QTest::newRow("3files") << "quacompress_extract3.zip"
-                            << (QStringList() << "test0.txt" << "test1.txt" << "test2.txt")
-                            << "tmp/quacompress_ext3/";
-}
-
-// Test extractDir
-void TestQuaCompress::extractDir()
-{
-    QFETCH(QString, zipName);
-    QFETCH(QStringList, fileNames);
-    QFETCH(QString, extractDir);
-
-    QDir curDir;
-    if (curDir.exists(zipName)) {
-        if (!curDir.remove(zipName))
-            QFAIL("Can't remove zip file");
-    }
-    if (!createTestFiles(fileNames)) {
-        QFAIL("Can't create test files");
-    }
-
-    QStringList fullPaths;
-    foreach (QString fileName, fileNames) {
-        fullPaths << "tmp/" + fileName;
-    }
-
-    // Create archive
-    QuaCompress().compressFiles(zipName, fullPaths);
-
-    // Extract
-    QStringList extracted = QuaCompress().extractDir(zipName, extractDir);
-    QCOMPARE(extracted.size(), fileNames.size());
-    foreach (QString fileName, fileNames) {
-        QVERIFY(QFile::exists(extractDir + fileName));
-    }
-
-    // Cleanup
-    removeTestFiles(fileNames);
-    curDir.remove(zipName);
-    QDir(extractDir).removeRecursively();
 }
 
 // Test data for addFile
@@ -388,11 +296,11 @@ void TestQuaCompress::addFile_data()
     QTest::addColumn<QString>("addedFile");
     QTest::addColumn<bool>("utf8");
 
-    QTest::newRow("simple") << "quacompress_add.zip"
+    QTest::newRow("simple") << "quacompress_addfile.zip"
                             << "test0.txt"
                             << "test1.txt"
                             << false;
-    QTest::newRow("utf8") << "quacompress_add_utf8.zip"
+    QTest::newRow("utf8") << "quacompress_addfile_utf8.zip"
                           << "test0.txt"
                           << QString::fromUtf8("тест.txt")
                           << true;
@@ -420,17 +328,25 @@ void TestQuaCompress::addFile()
         QFAIL("Can't create test files");
     }
 
-    // Create initial archive
-    QuaCompress().withUtf8Enabled(utf8).compressFile(zipName, "tmp/" + initialFile);
-
-    // Add file
+    // Create initial archive with one file
     bool result = QuaCompress()
+        .withUtf8Enabled(utf8)
+        .compressFile(zipName, "tmp/" + initialFile);
+    QVERIFY(result);
+
+    // Verify initial archive has 1 file
+    QStringList list = QuaExtract().getFileList(zipName);
+    QCOMPARE(list.size(), 1);
+    QVERIFY(list.contains(initialFile));
+
+    // Add another file to the archive
+    result = QuaCompress()
         .withUtf8Enabled(utf8)
         .addFile(zipName, "tmp/" + addedFile);
     QVERIFY(result);
 
-    // Verify both files are in archive
-    QStringList list = QuaCompress().getFileList(zipName);
+    // Verify archive now has 2 files
+    list = QuaExtract().getFileList(zipName);
     QCOMPARE(list.size(), 2);
     QVERIFY(list.contains(initialFile));
     QVERIFY(list.contains(addedFile));
@@ -440,8 +356,353 @@ void TestQuaCompress::addFile()
     curDir.remove(zipName);
 }
 
+// Test data for addFiles
+void TestQuaCompress::addFiles_data()
+{
+    QTest::addColumn<QString>("zipName");
+    QTest::addColumn<QStringList>("initialFiles");
+    QTest::addColumn<QStringList>("addedFiles");
+    QTest::addColumn<bool>("utf8");
+
+    QTest::newRow("simple") << "quacompress_addfiles.zip"
+                            << (QStringList() << "test0.txt")
+                            << (QStringList() << "test1.txt" << "test2.txt")
+                            << false;
+    QTest::newRow("utf8") << "quacompress_addfiles_utf8.zip"
+                          << (QStringList() << "test0.txt")
+                          << (QStringList() << QString::fromUtf8("файл1.txt") << QString::fromUtf8("файл2.txt"))
+                          << true;
+}
+
+// Test addFiles to existing archive
+void TestQuaCompress::addFiles()
+{
+    QFETCH(QString, zipName);
+    QFETCH(QStringList, initialFiles);
+    QFETCH(QStringList, addedFiles);
+    QFETCH(bool, utf8);
+
+    // Skip UTF-8 tests if platform doesn't support UTF-8
+    if (utf8 && !isPlatformUtf8()) {
+        QSKIP("Skipping UTF-8 test on non-UTF-8 platform");
+    }
+
+    QDir curDir;
+    if (curDir.exists(zipName)) {
+        if (!curDir.remove(zipName))
+            QFAIL("Can't remove zip file");
+    }
+
+    QStringList allFiles = initialFiles + addedFiles;
+    if (!createTestFiles(allFiles)) {
+        QFAIL("Can't create test files");
+    }
+
+    // Create initial archive
+    QStringList initialPaths;
+    foreach (QString fileName, initialFiles) {
+        initialPaths << "tmp/" + fileName;
+    }
+    bool result = QuaCompress()
+        .withUtf8Enabled(utf8)
+        .compressFiles(zipName, initialPaths);
+    QVERIFY(result);
+
+    // Add more files
+    QStringList addedPaths;
+    foreach (QString fileName, addedFiles) {
+        addedPaths << "tmp/" + fileName;
+    }
+    result = QuaCompress()
+        .withUtf8Enabled(utf8)
+        .addFiles(zipName, addedPaths);
+    QVERIFY(result);
+
+    // Verify all files are in archive
+    QStringList list = QuaExtract().getFileList(zipName);
+    QCOMPARE(list.size(), allFiles.size());
+    foreach (QString fileName, allFiles) {
+        QVERIFY(list.contains(fileName));
+    }
+
+    // Cleanup
+    removeTestFiles(allFiles);
+    curDir.remove(zipName);
+}
+
+// Test data for addDir
+void TestQuaCompress::addDir_data()
+{
+    QTest::addColumn<QString>("zipName");
+    QTest::addColumn<QString>("initialFile");
+    QTest::addColumn<QStringList>("dirFiles");
+    QTest::addColumn<int>("expectedTotalFiles");
+    QTest::addColumn<bool>("utf8");
+
+    QTest::newRow("simple") << "quacompress_adddir.zip"
+                            << "test0.txt"
+                            << (QStringList() << "testdir1/test1.txt" << "testdir1/test2.txt")
+                            << 3  // 1 initial + 2 added
+                            << false;
+    QTest::newRow("utf8") << "quacompress_adddir_utf8.zip"
+                          << "test0.txt"
+                          << (QStringList() << "testdir1/test1.txt")
+                          << 2  // 1 initial + 1 added
+                          << true;
+}
+
+// Test addDir to existing archive
+void TestQuaCompress::addDir()
+{
+    QFETCH(QString, zipName);
+    QFETCH(QString, initialFile);
+    QFETCH(QStringList, dirFiles);
+    QFETCH(int, expectedTotalFiles);
+    QFETCH(bool, utf8);
+
+    // Skip UTF-8 tests if platform doesn't support UTF-8
+    if (utf8 && !isPlatformUtf8()) {
+        QSKIP("Skipping UTF-8 test on non-UTF-8 platform");
+    }
+
+    QDir curDir;
+    if (curDir.exists(zipName)) {
+        if (!curDir.remove(zipName))
+            QFAIL("Can't remove zip file");
+    }
+
+    QStringList allFiles = QStringList() << initialFile;
+    allFiles << dirFiles;
+    if (!createTestFiles(allFiles)) {
+        QFAIL("Can't create test files");
+    }
+
+    // Create initial archive with one file
+    bool result = QuaCompress()
+        .withUtf8Enabled(utf8)
+        .compressFile(zipName, "tmp/" + initialFile);
+    QVERIFY(result);
+
+    // Add a directory to the archive
+    result = QuaCompress()
+        .withUtf8Enabled(utf8)
+        .addDir(zipName, "tmp/testdir1", true);
+    QVERIFY(result);
+
+    // Verify archive has all files
+    QStringList list = QuaExtract().getFileList(zipName);
+    QVERIFY(list.size() >= expectedTotalFiles);
+
+    // Cleanup
+    removeTestFiles(allFiles);
+    curDir.remove(zipName);
+}
+
+// ==================== TestQuaExtract ====================
+
+// Test data for extractFile
+void TestQuaExtract::extractFile_data()
+{
+    QTest::addColumn<QString>("zipName");
+    QTest::addColumn<QString>("fileName");
+    QTest::addColumn<QString>("extractPath");
+    QTest::addColumn<bool>("usePassword");
+    QTest::addColumn<QByteArray>("password");
+
+    QTest::newRow("simple") << "quaextract_file.zip"
+                            << "test0.txt"
+                            << "tmp/quaextract_out.txt"
+                            << false
+                            << QByteArray();
+    QTest::newRow("with-password") << "quaextract_file_pwd.zip"
+                                   << "test1.txt"
+                                   << "tmp/quaextract_pwd_out.txt"
+                                   << true
+                                   << QByteArray("secret123");
+}
+
+// Test extractFile
+void TestQuaExtract::extractFile()
+{
+    QFETCH(QString, zipName);
+    QFETCH(QString, fileName);
+    QFETCH(QString, extractPath);
+    QFETCH(bool, usePassword);
+    QFETCH(QByteArray, password);
+
+    QDir curDir;
+    if (curDir.exists(zipName)) {
+        if (!curDir.remove(zipName))
+            QFAIL("Can't remove zip file");
+    }
+    if (QFile::exists(extractPath)) {
+        if (!QFile::remove(extractPath))
+            QFAIL("Can't remove extracted file");
+    }
+    if (!createTestFiles(QStringList() << fileName)) {
+        QFAIL("Can't create test file");
+    }
+
+    // Create archive
+    QuaCompress compressor;
+    compressor.withUtf8Enabled();
+    if (usePassword) {
+        compressor.withPassword(password);
+    }
+    bool result = compressor.compressFile(zipName, "tmp/" + fileName);
+    QVERIFY(result);
+
+    // Extract single file
+    QString extracted;
+    if (usePassword) {
+        extracted = QuaExtract()
+            .withPassword(password)
+            .extractFile(zipName, fileName, extractPath);
+    } else {
+        extracted = QuaExtract()
+            .extractFile(zipName, fileName, extractPath);
+    }
+
+    QVERIFY(!extracted.isEmpty());
+    QVERIFY(QFile::exists(extractPath));
+
+    // Test wrong password fails
+    if (usePassword) {
+        QString wrongExtract = QuaExtract()
+            .withPassword(QByteArray("wrong"))
+            .extractFile(zipName, fileName, "tmp/wrong.txt");
+        QVERIFY(wrongExtract.isEmpty());
+    }
+
+    // Cleanup
+    removeTestFiles(QStringList() << fileName);
+    curDir.remove(zipName);
+    QFile::remove(extractPath);
+    QFile::remove("tmp/wrong.txt");
+}
+
+// Test data for extractFiles
+void TestQuaExtract::extractFiles_data()
+{
+    QTest::addColumn<QString>("zipName");
+    QTest::addColumn<QStringList>("fileNames");
+    QTest::addColumn<QStringList>("filesToExtract");
+    QTest::addColumn<QString>("extractDir");
+
+    QTest::newRow("extract-some") << "quaextract_files_some.zip"
+                                  << (QStringList() << "test0.txt" << "test1.txt" << "test2.txt")
+                                  << (QStringList() << "test0.txt" << "test2.txt")  // Only extract 2 of 3
+                                  << "tmp/quaextract_some/";
+    QTest::newRow("extract-single") << "quaextract_files_single.zip"
+                                    << (QStringList() << "test0.txt" << "test1.txt")
+                                    << (QStringList() << "test0.txt")  // Only extract 1 of 2
+                                    << "tmp/quaextract_single/";
+}
+
+// Test extractFiles
+void TestQuaExtract::extractFiles()
+{
+    QFETCH(QString, zipName);
+    QFETCH(QStringList, fileNames);
+    QFETCH(QStringList, filesToExtract);
+    QFETCH(QString, extractDir);
+
+    QDir curDir;
+    if (curDir.exists(zipName)) {
+        if (!curDir.remove(zipName))
+            QFAIL("Can't remove zip file");
+    }
+    if (!createTestFiles(fileNames)) {
+        QFAIL("Can't create test files");
+    }
+
+    QStringList fullPaths;
+    foreach (QString fileName, fileNames) {
+        fullPaths << "tmp/" + fileName;
+    }
+
+    // Create archive with all files
+    bool result = QuaCompress().compressFiles(zipName, fullPaths);
+    QVERIFY(result);
+
+    // Extract specific files
+    QStringList extracted = QuaExtract().extractFiles(zipName, filesToExtract, extractDir);
+
+    // Verify extraction
+    QCOMPARE(extracted.size(), filesToExtract.size());
+
+    // Verify extracted files exist
+    foreach (QString fileName, filesToExtract) {
+        QVERIFY(QFile::exists(extractDir + fileName));
+    }
+
+    // Verify non-extracted files don't exist
+    foreach (QString fileName, fileNames) {
+        if (!filesToExtract.contains(fileName)) {
+            QVERIFY(!QFile::exists(extractDir + fileName));
+        }
+    }
+
+    // Cleanup
+    removeTestFiles(fileNames);
+    curDir.remove(zipName);
+    QDir(extractDir).removeRecursively();
+}
+
+// Test data for extractDir
+void TestQuaExtract::extractDir_data()
+{
+    QTest::addColumn<QString>("zipName");
+    QTest::addColumn<QStringList>("fileNames");
+    QTest::addColumn<QString>("extractDir");
+
+    QTest::newRow("simple") << "quacompress_extract.zip"
+                            << (QStringList() << "test0.txt" << "test1.txt")
+                            << "tmp/quacompress_ext/";
+    QTest::newRow("3files") << "quacompress_extract3.zip"
+                            << (QStringList() << "test0.txt" << "test1.txt" << "test2.txt")
+                            << "tmp/quacompress_ext3/";
+}
+
+// Test extractDir
+void TestQuaExtract::extractDir()
+{
+    QFETCH(QString, zipName);
+    QFETCH(QStringList, fileNames);
+    QFETCH(QString, extractDir);
+
+    QDir curDir;
+    if (curDir.exists(zipName)) {
+        if (!curDir.remove(zipName))
+            QFAIL("Can't remove zip file");
+    }
+    if (!createTestFiles(fileNames)) {
+        QFAIL("Can't create test files");
+    }
+
+    QStringList fullPaths;
+    foreach (QString fileName, fileNames) {
+        fullPaths << "tmp/" + fileName;
+    }
+
+    // Create archive
+    QuaCompress().compressFiles(zipName, fullPaths);
+
+    // Extract
+    QStringList extracted = QuaExtract().extractDir(zipName, extractDir);
+    QCOMPARE(extracted.size(), fileNames.size());
+    foreach (QString fileName, fileNames) {
+        QVERIFY(QFile::exists(extractDir + fileName));
+    }
+
+    // Cleanup
+    removeTestFiles(fileNames);
+    curDir.remove(zipName);
+    QDir(extractDir).removeRecursively();
+}
+
 // Test data for getFileList
-void TestQuaCompress::getFileList_data()
+void TestQuaExtract::getFileList_data()
 {
     QTest::addColumn<QString>("zipName");
     QTest::addColumn<QStringList>("fileNames");
@@ -454,7 +715,7 @@ void TestQuaCompress::getFileList_data()
 }
 
 // Test getFileList
-void TestQuaCompress::getFileList()
+void TestQuaExtract::getFileList()
 {
     QFETCH(QString, zipName);
     QFETCH(QStringList, fileNames);
@@ -479,7 +740,7 @@ void TestQuaCompress::getFileList()
     QuaCompress().compressFiles(zipName, fullPaths);
 
     // Get file list
-    QStringList list = QuaCompress().getFileList(zipName);
+    QStringList list = QuaExtract().getFileList(zipName);
 
     QCOMPARE(list, shortNames);
 

--- a/qztest/testquacompress.cpp
+++ b/qztest/testquacompress.cpp
@@ -145,6 +145,11 @@ void TestQuaCompress::compressFile()
     QFETCH(JlCompress::Options::CompressionStrategy, compression);
     QFETCH(QByteArray, password);
 
+    // Skip UTF-8 tests if platform doesn't support UTF-8
+    if (utf8 && !isPlatformUtf8()) {
+        QSKIP("Skipping UTF-8 test on non-UTF-8 platform");
+    }
+
     QDir curDir;
     if (curDir.exists(zipName)) {
         if (!curDir.remove(zipName))
@@ -225,6 +230,11 @@ void TestQuaCompress::compressFiles()
     QFETCH(QStringList, fileNames);
     QFETCH(bool, utf8);
 
+    // Skip UTF-8 tests if platform doesn't support UTF-8
+    if (utf8 && !isPlatformUtf8()) {
+        QSKIP("Skipping UTF-8 test on non-UTF-8 platform");
+    }
+
     QDir curDir;
     if (curDir.exists(zipName)) {
         if (!curDir.remove(zipName))
@@ -291,6 +301,11 @@ void TestQuaCompress::compressDir()
     QFETCH(int, expectedMinFiles);
     QFETCH(bool, recursive);
     QFETCH(bool, utf8);
+
+    // Skip UTF-8 tests if platform doesn't support UTF-8
+    if (utf8 && !isPlatformUtf8()) {
+        QSKIP("Skipping UTF-8 test on non-UTF-8 platform");
+    }
 
     QDir curDir;
     if (curDir.exists(zipName)) {
@@ -393,6 +408,11 @@ void TestQuaCompress::addFile()
     QFETCH(QString, initialFile);
     QFETCH(QString, addedFile);
     QFETCH(bool, utf8);
+
+    // Skip UTF-8 tests if platform doesn't support UTF-8
+    if (utf8 && !isPlatformUtf8()) {
+        QSKIP("Skipping UTF-8 test on non-UTF-8 platform");
+    }
 
     QDir curDir;
     if (curDir.exists(zipName)) {

--- a/qztest/testquacompress.cpp
+++ b/qztest/testquacompress.cpp
@@ -30,6 +30,8 @@ See COPYING file for the full LGPL text.
 
 #include <QuaCompress.h>
 
+Q_DECLARE_METATYPE(JlCompress::Options::CompressionStrategy)
+
 // Test data for fluent API chaining
 void TestQuaCompress::fluentApiChaining_data()
 {

--- a/qztest/testquacompress.cpp
+++ b/qztest/testquacompress.cpp
@@ -1,0 +1,470 @@
+/*
+Copyright (C) 2025 cen1
+
+This file is part of QuaZip test suite.
+
+QuaZip is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2.1 of the License, or
+(at your option) any later version.
+
+QuaZip is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with QuaZip.  If not, see <http://www.gnu.org/licenses/>.
+
+See COPYING file for the full LGPL text.
+*/
+
+#include "testquacompress.h"
+
+#include "qztest.h"
+
+#include <QtCore/QDir>
+#include <QtCore/QFile>
+#include <QtCore/QFileInfo>
+#include <QtTest/QTest>
+
+#include <QuaCompress.h>
+
+// Test data for fluent API chaining
+void TestQuaCompress::fluentApiChaining_data()
+{
+    QTest::addColumn<QString>("zipName");
+    QTest::addColumn<QString>("fileName");
+
+    QTest::newRow("simple") << "quacompress_chain.zip" << "test0.txt";
+}
+
+// Test that fluent API chaining works correctly
+void TestQuaCompress::fluentApiChaining()
+{
+    QFETCH(QString, zipName);
+    QFETCH(QString, fileName);
+
+    // Create test file
+    QVERIFY(createTestFiles(QStringList() << fileName));
+
+    // Test method chaining returns reference to same object
+    QuaCompress compressor;
+    QuaCompress& ref1 = compressor.withUtf8Enabled(true);
+    QCOMPARE(&ref1, &compressor);
+
+    QuaCompress& ref2 = compressor.withCompression(JlCompress::Options::Better);
+    QCOMPARE(&ref2, &compressor);
+
+    QuaCompress& ref3 = compressor.withDateTime(QDateTime::currentDateTime());
+    QCOMPARE(&ref3, &compressor);
+
+    // Test that chained configuration works end-to-end
+    bool result = QuaCompress()
+        .withUtf8Enabled()
+        .withCompression(JlCompress::Options::Best)
+        .compressFile(zipName, "tmp/" + fileName);
+
+    QVERIFY(result);
+    QVERIFY(QFile::exists(zipName));
+
+    // Cleanup
+    removeTestFiles(QStringList() << fileName);
+    QFile::remove(zipName);
+}
+
+// Test data for compressFile - comprehensive matrix of options
+void TestQuaCompress::compressFile_data()
+{
+    QTest::addColumn<QString>("zipName");
+    QTest::addColumn<QString>("fileName");
+    QTest::addColumn<bool>("utf8");
+    QTest::addColumn<JlCompress::Options::CompressionStrategy>("compression");
+    QTest::addColumn<QByteArray>("password");
+
+    // Basic tests with different compression levels
+    QTest::newRow("simple") << "quacompress_simple.zip"
+                            << "test0.txt"
+                            << false
+                            << JlCompress::Options::Default
+                            << QByteArray();
+    QTest::newRow("storage") << "quacompress_storage.zip"
+                             << "test0.txt"
+                             << false
+                             << JlCompress::Options::Storage
+                             << QByteArray();
+    QTest::newRow("fastest") << "quacompress_fastest.zip"
+                             << "test0.txt"
+                             << false
+                             << JlCompress::Options::Fastest
+                             << QByteArray();
+    QTest::newRow("best") << "quacompress_best.zip"
+                          << "test0.txt"
+                          << false
+                          << JlCompress::Options::Best
+                          << QByteArray();
+
+    // UTF-8 tests with different scripts and compression levels
+    QTest::newRow("utf8-japanese-best") << "quacompress_utf8_ja.zip"
+                                        << QString::fromUtf8("ありがとう.txt")
+                                        << true
+                                        << JlCompress::Options::Best
+                          << QByteArray();
+    QTest::newRow("utf8-cyrillic-default") << "quacompress_utf8_ru.zip"
+                                           << QString::fromUtf8("Привет.txt")
+                                           << true
+                                           << JlCompress::Options::Default
+                                           << QByteArray();
+    QTest::newRow("utf8-chinese-fastest") << "quacompress_utf8_zh.zip"
+                                          << QString::fromUtf8("你好.txt")
+                                          << true
+                                          << JlCompress::Options::Fastest
+                             << QByteArray();
+
+    // Password tests
+    QTest::newRow("password-simple") << "quacompress_password.zip"
+                                     << "test0.txt"
+                                     << false
+                                     << JlCompress::Options::Default
+                                     << QByteArray("password123");
+    QTest::newRow("password-utf8-best") << "quacompress_password_utf8.zip"
+                                        << QString::fromUtf8("тест.txt")
+                                        << true
+                                        << JlCompress::Options::Best
+                                        << QByteArray("секрет");
+}
+
+// Test compressFile with various options
+void TestQuaCompress::compressFile()
+{
+    QFETCH(QString, zipName);
+    QFETCH(QString, fileName);
+    QFETCH(bool, utf8);
+    QFETCH(JlCompress::Options::CompressionStrategy, compression);
+    QFETCH(QByteArray, password);
+
+    QDir curDir;
+    if (curDir.exists(zipName)) {
+        if (!curDir.remove(zipName))
+            QFAIL("Can't remove zip file");
+    }
+    if (!createTestFiles(QStringList() << fileName)) {
+        QFAIL("Can't create test file");
+    }
+
+    // Compress file (fluent API)
+    bool result = QuaCompress()
+        .withUtf8Enabled(utf8)
+        .withCompression(compression)
+        .withPassword(password)
+        .compressFile(zipName, "tmp/" + fileName);
+    QVERIFY(result);
+    QVERIFY(QFile::exists(zipName));
+
+    // Verify file list (works without password)
+    QStringList fileList = QuaCompress().getFileList(zipName);
+    QCOMPARE(fileList.count(), 1);
+    QCOMPARE(fileList[0], fileName);
+
+    // Verify archive can be extracted
+    QStringList extracted;
+    if (!password.isEmpty()) {
+        // Test fluent API extraction
+        extracted = QuaCompress()
+            .withPassword(password)
+            .extractDir(zipName, "tmp/quacompress_extracted");
+        QCOMPARE(extracted.size(), 1);
+        QVERIFY(QFile::exists("tmp/quacompress_extracted/" + fileName));
+
+        // Also test parameter-based extraction
+        QDir("tmp/quacompress_extracted").removeRecursively();
+        extracted = QuaCompress().extractDir(zipName, "tmp/quacompress_extracted", password);
+        QCOMPARE(extracted.size(), 1);
+
+        // Test wrong password fails
+        QStringList wrongExtract = QuaCompress().extractDir(zipName, "tmp/quacompress_wrong", QByteArray("wrong"));
+        QCOMPARE(wrongExtract.size(), 0);
+        QDir("tmp/quacompress_wrong").removeRecursively();
+    } else {
+        // No password
+        extracted = QuaCompress().extractDir(zipName, "tmp/quacompress_extracted");
+        QCOMPARE(extracted.size(), 1);
+        QVERIFY(QFile::exists("tmp/quacompress_extracted/" + fileName));
+    }
+
+    // Cleanup
+    removeTestFiles(QStringList() << fileName);
+    curDir.remove(zipName);
+    QDir("tmp/quacompress_extracted").removeRecursively();
+}
+
+// Test data for compressFiles
+void TestQuaCompress::compressFiles_data()
+{
+    QTest::addColumn<QString>("zipName");
+    QTest::addColumn<QStringList>("fileNames");
+    QTest::addColumn<bool>("utf8");
+
+    QTest::newRow("simple") << "quacompress_files.zip"
+                            << (QStringList() << "test0.txt" << "test1.txt")
+                            << false;
+    QTest::newRow("utf8") << "quacompress_files_utf8.zip"
+                          << (QStringList() << "test0.txt" << QString::fromUtf8("тест.txt"))
+                          << true;
+    QTest::newRow("subdirs") << "quacompress_subdirs.zip"
+                             << (QStringList() << "subdir1/test1.txt" << "subdir2/test2.txt")
+                             << false;
+}
+
+// Test compressFiles with multiple files
+void TestQuaCompress::compressFiles()
+{
+    QFETCH(QString, zipName);
+    QFETCH(QStringList, fileNames);
+    QFETCH(bool, utf8);
+
+    QDir curDir;
+    if (curDir.exists(zipName)) {
+        if (!curDir.remove(zipName))
+            QFAIL("Can't remove zip file");
+    }
+    if (!createTestFiles(fileNames)) {
+        QFAIL("Can't create test files");
+    }
+
+    QStringList realNamesList, shortNamesList;
+    foreach (QString fileName, fileNames) {
+        QString realName = "tmp/" + fileName;
+        realNamesList += realName;
+        shortNamesList += QFileInfo(realName).fileName();
+    }
+
+    // Compress files
+    bool result = QuaCompress()
+        .withUtf8Enabled(utf8)
+        .compressFiles(zipName, realNamesList);
+    QVERIFY(result);
+
+    // Verify file list
+    QStringList list = QuaCompress().getFileList(zipName);
+    QCOMPARE(list, shortNamesList);
+
+    // Cleanup
+    removeTestFiles(fileNames);
+    curDir.remove(zipName);
+}
+
+// Test data for compressDir
+void TestQuaCompress::compressDir_data()
+{
+    QTest::addColumn<QString>("zipName");
+    QTest::addColumn<QStringList>("fileNames");
+    QTest::addColumn<int>("expectedMinFiles");
+    QTest::addColumn<bool>("recursive");
+    QTest::addColumn<bool>("utf8");
+
+    QTest::newRow("simple-recursive") << "quacompress_dir.zip"
+        << (QStringList() << "test0.txt" << "testdir1/test1.txt"
+            << "testdir2/test2.txt" << "testdir2/subdir/test2sub.txt")
+        << 4  // At least 4 files
+        << true
+        << false;
+    QTest::newRow("recursive-utf8") << "quacompress_dir_utf8.zip"
+        << (QStringList() << "test0.txt" << "testdir1/test1.txt")
+        << 2  // At least 2 files
+        << true
+        << true;
+    QTest::newRow("non-recursive") << "quacompress_dir_nonrec.zip"
+        << (QStringList() << "test0.txt" << "testdir1/test1.txt")
+        << 1  // Only test0.txt (non-recursive)
+        << false
+        << false;
+}
+
+// Test compressDir with recursive/non-recursive options
+void TestQuaCompress::compressDir()
+{
+    QFETCH(QString, zipName);
+    QFETCH(QStringList, fileNames);
+    QFETCH(int, expectedMinFiles);
+    QFETCH(bool, recursive);
+    QFETCH(bool, utf8);
+
+    QDir curDir;
+    if (curDir.exists(zipName)) {
+        if (!curDir.remove(zipName))
+            QFAIL("Can't remove zip file");
+    }
+    if (!createTestFiles(fileNames)) {
+        QFAIL("Can't create test files");
+    }
+
+    // Compress directory
+    bool result = QuaCompress()
+        .withUtf8Enabled(utf8)
+        .compressDir(zipName, "tmp", recursive);
+    QVERIFY(result);
+
+    // Verify file list has at least the expected number of files
+    QStringList list = QuaCompress().getFileList(zipName);
+    QVERIFY(list.size() >= expectedMinFiles);
+
+    // Cleanup
+    removeTestFiles(fileNames);
+    curDir.remove(zipName);
+}
+
+// Test data for extractDir
+void TestQuaCompress::extractDir_data()
+{
+    QTest::addColumn<QString>("zipName");
+    QTest::addColumn<QStringList>("fileNames");
+    QTest::addColumn<QString>("extractDir");
+
+    QTest::newRow("simple") << "quacompress_extract.zip"
+                            << (QStringList() << "test0.txt" << "test1.txt")
+                            << "tmp/quacompress_ext/";
+    QTest::newRow("3files") << "quacompress_extract3.zip"
+                            << (QStringList() << "test0.txt" << "test1.txt" << "test2.txt")
+                            << "tmp/quacompress_ext3/";
+}
+
+// Test extractDir
+void TestQuaCompress::extractDir()
+{
+    QFETCH(QString, zipName);
+    QFETCH(QStringList, fileNames);
+    QFETCH(QString, extractDir);
+
+    QDir curDir;
+    if (curDir.exists(zipName)) {
+        if (!curDir.remove(zipName))
+            QFAIL("Can't remove zip file");
+    }
+    if (!createTestFiles(fileNames)) {
+        QFAIL("Can't create test files");
+    }
+
+    QStringList fullPaths;
+    foreach (QString fileName, fileNames) {
+        fullPaths << "tmp/" + fileName;
+    }
+
+    // Create archive
+    QuaCompress().compressFiles(zipName, fullPaths);
+
+    // Extract
+    QStringList extracted = QuaCompress().extractDir(zipName, extractDir);
+    QCOMPARE(extracted.size(), fileNames.size());
+    foreach (QString fileName, fileNames) {
+        QVERIFY(QFile::exists(extractDir + fileName));
+    }
+
+    // Cleanup
+    removeTestFiles(fileNames);
+    curDir.remove(zipName);
+    QDir(extractDir).removeRecursively();
+}
+
+// Test data for addFile
+void TestQuaCompress::addFile_data()
+{
+    QTest::addColumn<QString>("zipName");
+    QTest::addColumn<QString>("initialFile");
+    QTest::addColumn<QString>("addedFile");
+    QTest::addColumn<bool>("utf8");
+
+    QTest::newRow("simple") << "quacompress_add.zip"
+                            << "test0.txt"
+                            << "test1.txt"
+                            << false;
+    QTest::newRow("utf8") << "quacompress_add_utf8.zip"
+                          << "test0.txt"
+                          << QString::fromUtf8("тест.txt")
+                          << true;
+}
+
+// Test addFile to existing archive
+void TestQuaCompress::addFile()
+{
+    QFETCH(QString, zipName);
+    QFETCH(QString, initialFile);
+    QFETCH(QString, addedFile);
+    QFETCH(bool, utf8);
+
+    QDir curDir;
+    if (curDir.exists(zipName)) {
+        if (!curDir.remove(zipName))
+            QFAIL("Can't remove zip file");
+    }
+    if (!createTestFiles(QStringList() << initialFile << addedFile)) {
+        QFAIL("Can't create test files");
+    }
+
+    // Create initial archive
+    QuaCompress().withUtf8Enabled(utf8).compressFile(zipName, "tmp/" + initialFile);
+
+    // Add file
+    bool result = QuaCompress()
+        .withUtf8Enabled(utf8)
+        .addFile(zipName, "tmp/" + addedFile);
+    QVERIFY(result);
+
+    // Verify both files are in archive
+    QStringList list = QuaCompress().getFileList(zipName);
+    QCOMPARE(list.size(), 2);
+    QVERIFY(list.contains(initialFile));
+    QVERIFY(list.contains(addedFile));
+
+    // Cleanup
+    removeTestFiles(QStringList() << initialFile << addedFile);
+    curDir.remove(zipName);
+}
+
+// Test data for getFileList
+void TestQuaCompress::getFileList_data()
+{
+    QTest::addColumn<QString>("zipName");
+    QTest::addColumn<QStringList>("fileNames");
+
+    QTest::newRow("2files") << "quacompress_list2.zip"
+                            << (QStringList() << "test0.txt" << "test1.txt");
+    QTest::newRow("5files") << "quacompress_list5.zip"
+                            << (QStringList() << "test0.txt" << "test1.txt" << "test2.txt"
+                                              << "test3.txt" << "test4.txt");
+}
+
+// Test getFileList
+void TestQuaCompress::getFileList()
+{
+    QFETCH(QString, zipName);
+    QFETCH(QStringList, fileNames);
+
+    QDir curDir;
+    if (curDir.exists(zipName)) {
+        if (!curDir.remove(zipName))
+            QFAIL("Can't remove zip file");
+    }
+    if (!createTestFiles(fileNames)) {
+        QFAIL("Can't create test files");
+    }
+
+    QStringList fullPaths;
+    QStringList shortNames;
+    foreach (QString fileName, fileNames) {
+        fullPaths << "tmp/" + fileName;
+        shortNames << fileName;
+    }
+
+    // Create archive
+    QuaCompress().compressFiles(zipName, fullPaths);
+
+    // Get file list
+    QStringList list = QuaCompress().getFileList(zipName);
+
+    QCOMPARE(list, shortNames);
+
+    // Cleanup
+    removeTestFiles(fileNames);
+    curDir.remove(zipName);
+}

--- a/qztest/testquacompress.cpp
+++ b/qztest/testquacompress.cpp
@@ -183,13 +183,10 @@ void TestQuaCompress::compressFile()
         QCOMPARE(extracted.size(), 1);
         QVERIFY(QFile::exists("tmp/quacompress_extracted/" + fileName));
 
-        // Also test parameter-based extraction
-        QDir("tmp/quacompress_extracted").removeRecursively();
-        extracted = QuaCompress().extractDir(zipName, "tmp/quacompress_extracted", password);
-        QCOMPARE(extracted.size(), 1);
-
         // Test wrong password fails
-        QStringList wrongExtract = QuaCompress().extractDir(zipName, "tmp/quacompress_wrong", QByteArray("wrong"));
+        QStringList wrongExtract = QuaCompress()
+            .withPassword(QByteArray("wrong"))
+            .extractDir(zipName, "tmp/quacompress_wrong");
         QCOMPARE(wrongExtract.size(), 0);
         QDir("tmp/quacompress_wrong").removeRecursively();
     } else {

--- a/qztest/testquacompress.h
+++ b/qztest/testquacompress.h
@@ -27,18 +27,29 @@ See COPYING file for the full LGPL text.
 class TestQuaCompress: public QObject {
     Q_OBJECT
 private slots:
-    void fluentApiChaining_data();
-    void fluentApiChaining();
     void compressFile_data();
     void compressFile();
     void compressFiles_data();
     void compressFiles();
     void compressDir_data();
     void compressDir();
-    void extractDir_data();
-    void extractDir();
     void addFile_data();
     void addFile();
+    void addFiles_data();
+    void addFiles();
+    void addDir_data();
+    void addDir();
+};
+
+class TestQuaExtract: public QObject {
+    Q_OBJECT
+private slots:
+    void extractFile_data();
+    void extractFile();
+    void extractFiles_data();
+    void extractFiles();
+    void extractDir_data();
+    void extractDir();
     void getFileList_data();
     void getFileList();
 };

--- a/qztest/testquacompress.h
+++ b/qztest/testquacompress.h
@@ -1,0 +1,46 @@
+#ifndef QUAZIP_TEST_QUACOMPRESS_H
+#define QUAZIP_TEST_QUACOMPRESS_H
+
+/*
+Copyright (C) 2025 cen1
+
+This file is part of QuaZip test suite.
+
+QuaZip is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2.1 of the License, or
+(at your option) any later version.
+
+QuaZip is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with QuaZip.  If not, see <http://www.gnu.org/licenses/>.
+
+See COPYING file for the full LGPL text.
+*/
+
+#include <QtCore/QObject>
+
+class TestQuaCompress: public QObject {
+    Q_OBJECT
+private slots:
+    void fluentApiChaining_data();
+    void fluentApiChaining();
+    void compressFile_data();
+    void compressFile();
+    void compressFiles_data();
+    void compressFiles();
+    void compressDir_data();
+    void compressDir();
+    void extractDir_data();
+    void extractDir();
+    void addFile_data();
+    void addFile();
+    void getFileList_data();
+    void getFileList();
+};
+
+#endif // QUAZIP_TEST_QUACOMPRESS_H

--- a/qztest/testutf8_compress.cpp
+++ b/qztest/testutf8_compress.cpp
@@ -1,0 +1,74 @@
+/*
+Copyright (C) 2025 cen1
+
+This file is part of QuaZip test suite.
+
+QuaZip is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2.1 of the License, or
+(at your option) any later version.
+
+QuaZip is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with QuaZip.  If not, see <http://www.gnu.org/licenses/>.
+
+See COPYING file for the full LGPL text.
+*/
+
+#include "testutf8_compress.h"
+
+#include "qztest.h"
+
+#include <QtCore/QDir>
+#include <QtTest/QTest>
+
+#include <JlCompress.h>
+
+/*
+ * The purpose of this test is to create archives with UTF-8 filenames
+ * in a UTF-8 locale environment. These archives will be uploaded as artifacts
+ * and then extracted in a C locale environment to verify proper handling
+ * of UTF-8 filenames.
+ */
+void TestUtf8Compress::compressUtf8Files()
+{
+    // Test filenames with various UTF-8 characters
+    QStringList testFiles;
+    testFiles << QString::fromUtf8("файл.txt");        // Cyrillic
+    testFiles << QString::fromUtf8("ありがとう.txt");    // Japanese
+    testFiles << QString::fromUtf8("你好.txt");         // Chinese
+    testFiles << QString::fromUtf8("Привет.txt");      // Cyrillic
+    testFiles << QString::fromUtf8("测试.txt");         // Chinese
+
+    // Create test files
+    QVERIFY(createTestFiles(testFiles));
+
+    // Compress each file individually with UTF-8 enabled
+    int fileIndex = 0;
+    for (const QString &fileName : testFiles) {
+        QString zipName = QString("utf8_%1.zip").arg(fileIndex++);
+        QString filePath = "tmp/" + fileName;
+
+        qDebug() << "Creating UTF-8 archive:" << zipName << "with file:" << fileName;
+
+        JlCompress::Options options;
+        options.setUtf8Enabled(true);
+
+        QVERIFY(JlCompress::compressFile(zipName, filePath, options));
+        QVERIFY(QFile::exists(zipName));
+
+        // Verify the archive contains the correct filename
+        QStringList fileList = JlCompress::getFileList(zipName);
+        QCOMPARE(fileList.size(), 1);
+        QCOMPARE(fileList[0], fileName);
+    }
+
+    // Cleanup test files
+    removeTestFiles(testFiles);
+
+    qDebug() << "UTF-8 compression tests completed successfully";
+}

--- a/qztest/testutf8_compress.cpp
+++ b/qztest/testutf8_compress.cpp
@@ -31,30 +31,40 @@ See COPYING file for the full LGPL text.
 
 /*
  * The purpose of this test is to create archives with UTF-8 filenames
- * in a UTF-8 locale environment. These archives will be uploaded as artifacts
- * and then extracted in a C locale environment to verify proper handling
- * of UTF-8 filenames.
+ * in a UTF-8 locale environment. This test creates two types of archives:
+ * - With UTF-8 flag enabled (utf8_with_flag_*.zip)
+ * - Without UTF-8 flag (utf8_no_flag_*.zip)
+ *
+ * These archives are uploaded as artifacts and extracted on various platforms
+ * to test decompression behavior.
+ *
+ * IMPORTANT: This test should only run on UTF-8 locale systems to ensure
+ * files are created correctly. Testing non-UTF-8 locales is done during
+ * decompression, not compression.
  */
 void TestUtf8Compress::compressUtf8Files()
 {
+    // Verify we're running on a UTF-8 system
+    QByteArray locale = qgetenv("LC_ALL");
+    if (locale.isEmpty()) locale = qgetenv("LANG");
+    qDebug() << "Current locale:" << locale;
+
     // Test filenames with various UTF-8 characters
     QStringList testFiles;
-    testFiles << QString::fromUtf8("файл.txt");        // Cyrillic
-    testFiles << QString::fromUtf8("ありがとう.txt");    // Japanese
-    testFiles << QString::fromUtf8("你好.txt");         // Chinese
-    testFiles << QString::fromUtf8("Привет.txt");      // Cyrillic
-    testFiles << QString::fromUtf8("测试.txt");         // Chinese
+    testFiles << QString::fromUtf8("файл.txt");        // Cyrillic (4 chars)
+    testFiles << QString::fromUtf8("ありがとう.txt");    // Japanese (5 chars)
+    testFiles << QString::fromUtf8("你好.txt");         // Chinese (2 chars)
+    testFiles << QString::fromUtf8("Привет.txt");      // Cyrillic (6 chars)
+    testFiles << QString::fromUtf8("测试.txt");         // Chinese (2 chars)
 
-    // Check if we're in C locale to demonstrate filename mangling
-    bool isCompressBad = qgetenv("TEST_UTF8_COMPRESS_BAD") == "true";
+    // Determine which type of archive to create
+    bool withUtf8Flag = qgetenv("TEST_UTF8_WITH_FLAG") == "true";
+    QString prefix = withUtf8Flag ? "utf8_with_flag" : "utf8_no_flag";
 
-    if (isCompressBad) {
-        qDebug() << "\n========================================";
-        qDebug() << "Compressing UTF-8 filenames WITHOUT UTF-8 flag";
-        qDebug() << "Locale:" << (qgetenv("LC_ALL").isEmpty() ? qgetenv("LANG") : qgetenv("LC_ALL"));
-        qDebug() << "On non-UTF-8 systems, filenames will be mangled";
-        qDebug() << "========================================";
-    }
+    qDebug() << "\n========================================";
+    qDebug() << "Creating archives:" << prefix;
+    qDebug() << "UTF-8 flag:" << (withUtf8Flag ? "ENABLED" : "DISABLED");
+    qDebug() << "========================================";
 
     // Create test files
     QVERIFY(createTestFiles(testFiles));
@@ -62,51 +72,32 @@ void TestUtf8Compress::compressUtf8Files()
     // Compress each file individually
     int fileIndex = 0;
     for (const QString &fileName : testFiles) {
-        QString zipName = QString("utf8_%1.zip").arg(fileIndex++);
+        QString zipName = QString("%1_%2.zip").arg(prefix).arg(fileIndex++);
         QString filePath = "tmp/" + fileName;
 
         JlCompress::Options options;
-        options.setUtf8Enabled(!isCompressBad);  // Disable UTF-8 for "bad" test
+        options.setUtf8Enabled(withUtf8Flag);
 
+        qDebug() << "Compressing:" << fileName << "->" << zipName;
         QVERIFY(JlCompress::compressFile(zipName, filePath, options));
         QVERIFY(QFile::exists(zipName));
 
-        // Get the filename as stored in archive
+        // Verify the file was stored correctly
         QStringList fileList = JlCompress::getFileList(zipName);
         QCOMPARE(fileList.size(), 1);
 
-        if (isCompressBad) {
-            // In non-UTF-8 locale without UTF-8 flag, filenames get mangled
-            // The behavior differs by platform:
-            // - Windows: Unmappable characters are replaced with '?' (0x3f)
-            // - Linux: Unmappable characters are dropped entirely (null truncation)
-            qDebug() << "Original filename:" << fileName;
-            qDebug() << "Filename in archive:" << fileList[0];
-            qDebug() << "Raw bytes:" << fileList[0].toLocal8Bit().toHex();
+        // On UTF-8 systems, filename should always be preserved in the archive
+        // (whether UTF-8 flag is set or not, the bytes are UTF-8)
+        QCOMPARE(fileList[0], fileName);
 
-            QString archivedName = fileList[0];
-
-#ifdef Q_OS_WIN
-            // On Windows, expect '?' replacement: one or more '?' followed by .txt
-            // Example: "файл.txt" -> "????.txt"
-            QRegularExpression windowsPattern("^\\?+\\.txt$");
-            QVERIFY2(windowsPattern.match(archivedName).hasMatch(),
-                     qPrintable(QString("Windows should produce pattern '?+.txt', got: %1").arg(archivedName)));
-#else
-            // On Linux with non-UTF-8 locale, unmappable characters are dropped
-            // This results in just ".txt" (null truncation)
-            // Example: "файл.txt" -> ".txt"
-            QCOMPARE(archivedName, QString(".txt"));
-#endif
-            qDebug() << "---";
-        } else {
-            // With UTF-8 flag, filename should match
-            QCOMPARE(fileList[0], fileName);
-        }
+        qDebug() << "  Stored as:" << fileList[0];
+        qDebug() << "  Bytes:" << fileList[0].toUtf8().toHex();
     }
 
     // Cleanup test files
     removeTestFiles(testFiles);
 
-    qDebug() << "UTF-8 compression tests completed successfully";
+    qDebug() << "========================================";
+    qDebug() << "Successfully created" << testFiles.size() << prefix << "archives";
+    qDebug() << "========================================";
 }

--- a/qztest/testutf8_compress.cpp
+++ b/qztest/testutf8_compress.cpp
@@ -53,8 +53,6 @@ void TestUtf8Compress::compressUtf8Files()
         QString zipName = QString("utf8_%1.zip").arg(fileIndex++);
         QString filePath = "tmp/" + fileName;
 
-        qDebug() << "Creating UTF-8 archive:" << zipName << "with file:" << fileName;
-
         JlCompress::Options options;
         options.setUtf8Enabled(true);
 

--- a/qztest/testutf8_compress.cpp
+++ b/qztest/testutf8_compress.cpp
@@ -24,6 +24,7 @@ See COPYING file for the full LGPL text.
 #include "qztest.h"
 
 #include <QtCore/QDir>
+#include <QtCore/QRegularExpression>
 #include <QtTest/QTest>
 
 #include <JlCompress.h>
@@ -75,13 +76,29 @@ void TestUtf8Compress::compressUtf8Files()
         QCOMPARE(fileList.size(), 1);
 
         if (isCompressBad) {
-            // In C locale without UTF-8 flag, show what actually happens
+            // In non-UTF-8 locale without UTF-8 flag, filenames get mangled
+            // The behavior differs by platform:
+            // - Windows: Unmappable characters are replaced with '?' (0x3f)
+            // - Linux: Unmappable characters are dropped entirely (null truncation)
             qDebug() << "Original filename:" << fileName;
             qDebug() << "Filename in archive:" << fileList[0];
             qDebug() << "Raw bytes:" << fileList[0].toLocal8Bit().toHex();
+
+            QString archivedName = fileList[0];
+
+#ifdef Q_OS_WIN
+            // On Windows, expect '?' replacement: one or more '?' followed by .txt
+            // Example: "файл.txt" -> "????.txt"
+            QRegularExpression windowsPattern("^\\?+\\.txt$");
+            QVERIFY2(windowsPattern.match(archivedName).hasMatch(),
+                     qPrintable(QString("Windows should produce pattern '?+.txt', got: %1").arg(archivedName)));
+#else
+            // On Linux with non-UTF-8 locale, unmappable characters are dropped
+            // This results in just ".txt" (null truncation)
+            // Example: "файл.txt" -> ".txt"
+            QCOMPARE(archivedName, QString(".txt"));
+#endif
             qDebug() << "---";
-            // Note: On Qt6 Linux, Qt forces UTF-8 so filenames may look correct
-            // On Qt5 or Windows with non-UTF-8 locale, we'll see actual mangling
         } else {
             // With UTF-8 flag, filename should match
             QCOMPARE(fileList[0], fileName);

--- a/qztest/testutf8_compress.cpp
+++ b/qztest/testutf8_compress.cpp
@@ -44,25 +44,48 @@ void TestUtf8Compress::compressUtf8Files()
     testFiles << QString::fromUtf8("Привет.txt");      // Cyrillic
     testFiles << QString::fromUtf8("测试.txt");         // Chinese
 
+    // Check if we're in C locale to demonstrate filename mangling
+    bool isCompressBad = qgetenv("TEST_UTF8_COMPRESS_BAD") == "true";
+
+    if (isCompressBad) {
+        qDebug() << "\n========================================";
+        qDebug() << "Compressing UTF-8 filenames WITHOUT UTF-8 flag";
+        qDebug() << "Locale:" << (qgetenv("LC_ALL").isEmpty() ? qgetenv("LANG") : qgetenv("LC_ALL"));
+        qDebug() << "On non-UTF-8 systems, filenames will be mangled";
+        qDebug() << "========================================";
+    }
+
     // Create test files
     QVERIFY(createTestFiles(testFiles));
 
-    // Compress each file individually with UTF-8 enabled
+    // Compress each file individually
     int fileIndex = 0;
     for (const QString &fileName : testFiles) {
         QString zipName = QString("utf8_%1.zip").arg(fileIndex++);
         QString filePath = "tmp/" + fileName;
 
         JlCompress::Options options;
-        options.setUtf8Enabled(true);
+        options.setUtf8Enabled(!isCompressBad);  // Disable UTF-8 for "bad" test
 
         QVERIFY(JlCompress::compressFile(zipName, filePath, options));
         QVERIFY(QFile::exists(zipName));
 
-        // Verify the archive contains the correct filename
+        // Get the filename as stored in archive
         QStringList fileList = JlCompress::getFileList(zipName);
         QCOMPARE(fileList.size(), 1);
-        QCOMPARE(fileList[0], fileName);
+
+        if (isCompressBad) {
+            // In C locale without UTF-8 flag, show what actually happens
+            qDebug() << "Original filename:" << fileName;
+            qDebug() << "Filename in archive:" << fileList[0];
+            qDebug() << "Raw bytes:" << fileList[0].toLocal8Bit().toHex();
+            qDebug() << "---";
+            // Note: On Qt6 Linux, Qt forces UTF-8 so filenames may look correct
+            // On Qt5 or Windows with non-UTF-8 locale, we'll see actual mangling
+        } else {
+            // With UTF-8 flag, filename should match
+            QCOMPARE(fileList[0], fileName);
+        }
     }
 
     // Cleanup test files

--- a/qztest/testutf8_compress.h
+++ b/qztest/testutf8_compress.h
@@ -1,0 +1,33 @@
+#ifndef QUAZIP_TEST_UTF8_COMPRESS_H
+#define QUAZIP_TEST_UTF8_COMPRESS_H
+
+/*
+Copyright (C) 2025 cen1
+
+This file is part of QuaZip test suite.
+
+QuaZip is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2.1 of the License, or
+(at your option) any later version.
+
+QuaZip is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with QuaZip.  If not, see <http://www.gnu.org/licenses/>.
+
+See COPYING file for the full LGPL text.
+*/
+
+#include <QtCore/QObject>
+
+class TestUtf8Compress: public QObject {
+    Q_OBJECT
+private slots:
+    void compressUtf8Files();
+};
+
+#endif // QUAZIP_TEST_UTF8_COMPRESS_H

--- a/qztest/testutf8_decompress.cpp
+++ b/qztest/testutf8_decompress.cpp
@@ -72,8 +72,10 @@ void TestUtf8Decompress::decompressUtf8Files()
             qDebug() << "Extracted files:" << extracted;
 
             // Verify files exist (even with mangled names)
+            // Note: We include QDir::Hidden because UTF-8 filenames can get so mangled in C locale
+            // that only the extension remains (e.g., "файл.txt" -> ".txt"), which is a hidden file
             QDir extractedDir(extractDir);
-            QStringList extractedFiles = extractedDir.entryList(QDir::Files);
+            QStringList extractedFiles = extractedDir.entryList(QDir::Files | QDir::Hidden);
             QVERIFY2(!extractedFiles.isEmpty(), qPrintable(QString("No files found after extraction from: %1").arg(archiveFile)));
 
             // In C locale, UTF-8 filenames should be mangled (not properly decoded)

--- a/qztest/testutf8_decompress.cpp
+++ b/qztest/testutf8_decompress.cpp
@@ -43,7 +43,9 @@ void TestUtf8Decompress::decompressUtf8Files()
     // Find artifact directories containing UTF-8 archives
     QDirIterator it(QDir::currentPath(), QStringList() << "utf8_archives_*", QDir::Dirs, QDirIterator::Subdirectories);
 
-    QVERIFY(it.hasNext());
+    QVERIFY2(it.hasNext(), "No UTF-8 archive artifacts found");
+
+    int totalArchivesProcessed = 0;
 
     while (it.hasNext()) {
         QFileInfo artifactDir(it.next());
@@ -52,7 +54,7 @@ void TestUtf8Decompress::decompressUtf8Files()
         QDir dir(artifactDir.absoluteFilePath());
         QStringList zipFiles = dir.entryList(QStringList() << "utf8_*.zip", QDir::Files);
 
-        QVERIFY(!zipFiles.isEmpty());
+        QVERIFY2(!zipFiles.isEmpty(), qPrintable(QString("No UTF-8 zip files found in artifact directory: %1").arg(artifactDir.fileName())));
 
         for (const QString &archiveFile : zipFiles) {
             QString zipPath = dir.absoluteFilePath(archiveFile);
@@ -65,27 +67,30 @@ void TestUtf8Decompress::decompressUtf8Files()
             QStringList extracted = JlCompress::extractDir(zipPath, extractDir);
 
             // We expect extraction to succeed, but filenames will be mangled in C locale
-            QVERIFY(!extracted.isEmpty());
+            QVERIFY2(!extracted.isEmpty(), qPrintable(QString("Failed to extract any files from: %1").arg(archiveFile)));
 
             qDebug() << "Extracted files:" << extracted;
 
             // Verify files exist (even with mangled names)
             QDir extractedDir(extractDir);
             QStringList extractedFiles = extractedDir.entryList(QDir::Files);
-            QVERIFY(!extractedFiles.isEmpty());
+            QVERIFY2(!extractedFiles.isEmpty(), qPrintable(QString("No files found after extraction from: %1").arg(archiveFile)));
 
             // In C locale, UTF-8 filenames should be mangled (not properly decoded)
             // We just verify that extraction doesn't crash and produces some output
             for (const QString &extractedFile : extractedFiles) {
                 QString filePath = extractedDir.absoluteFilePath(extractedFile);
-                QVERIFY(QFile::exists(filePath));
+                QVERIFY2(QFile::exists(filePath), qPrintable(QString("Extracted file does not exist: %1").arg(filePath)));
                 qDebug() << "Found extracted file (possibly mangled):" << extractedFile;
             }
 
             // Cleanup
             extractedDir.removeRecursively();
+
+            totalArchivesProcessed++;
         }
     }
 
-    qDebug() << "UTF-8 decompression tests completed successfully";
+    QVERIFY2(totalArchivesProcessed > 0, "No UTF-8 archives were processed");
+    qDebug() << "UTF-8 decompression tests completed successfully. Processed" << totalArchivesProcessed << "archives.";
 }

--- a/qztest/testutf8_decompress.cpp
+++ b/qztest/testutf8_decompress.cpp
@@ -1,0 +1,91 @@
+/*
+Copyright (C) 2025 cen1
+
+This file is part of QuaZip test suite.
+
+QuaZip is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2.1 of the License, or
+(at your option) any later version.
+
+QuaZip is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with QuaZip.  If not, see <http://www.gnu.org/licenses/>.
+
+See COPYING file for the full LGPL text.
+*/
+
+#include "testutf8_decompress.h"
+
+#include "qztest.h"
+
+#include <QtCore/QDir>
+#include <QtCore/QDirIterator>
+#include <QtCore/QFileInfo>
+#include <QtTest/QTest>
+
+#include <JlCompress.h>
+
+/*
+ * The purpose of this test is to extract UTF-8 archives created in a UTF-8 locale
+ * but extracted in a C locale environment. We expect the filenames to be mangled
+ * (not properly decoded as UTF-8) since we're in a C locale.
+ */
+void TestUtf8Decompress::decompressUtf8Files()
+{
+    qDebug() << "Performing UTF-8 decompress tests in " << QDir::currentPath();
+    qDebug() << "Current locale: LC_ALL=" << qgetenv("LC_ALL") << "LANG=" << qgetenv("LANG");
+
+    // Find artifact directories containing UTF-8 archives
+    QDirIterator it(QDir::currentPath(), QStringList() << "utf8_archives_*", QDir::Dirs, QDirIterator::Subdirectories);
+
+    QVERIFY(it.hasNext());
+
+    while (it.hasNext()) {
+        QFileInfo artifactDir(it.next());
+        qDebug() << "====== Found artifact:" << artifactDir.fileName() << "======";
+
+        QDir dir(artifactDir.absoluteFilePath());
+        QStringList zipFiles = dir.entryList(QStringList() << "utf8_*.zip", QDir::Files);
+
+        QVERIFY(!zipFiles.isEmpty());
+
+        for (const QString &archiveFile : zipFiles) {
+            QString zipPath = dir.absoluteFilePath(archiveFile);
+            qDebug() << "Processing archive:" << archiveFile;
+
+            // Extract to a temporary directory
+            QString extractDir = QString("tmp/utf8_extract_%1").arg(archiveFile.left(archiveFile.length() - 4));
+            QDir().mkpath(extractDir);
+
+            QStringList extracted = JlCompress::extractDir(zipPath, extractDir);
+
+            // We expect extraction to succeed, but filenames will be mangled in C locale
+            QVERIFY(!extracted.isEmpty());
+
+            qDebug() << "Extracted files:" << extracted;
+
+            // Verify files exist (even with mangled names)
+            QDir extractedDir(extractDir);
+            QStringList extractedFiles = extractedDir.entryList(QDir::Files);
+            QVERIFY(!extractedFiles.isEmpty());
+
+            // In C locale, UTF-8 filenames should be mangled (not properly decoded)
+            // We just verify that extraction doesn't crash and produces some output
+            for (const QString &extractedFile : extractedFiles) {
+                QString filePath = extractedDir.absoluteFilePath(extractedFile);
+                QVERIFY(QFile::exists(filePath));
+                qDebug() << "Found extracted file (possibly mangled):" << extractedFile;
+            }
+
+            // Cleanup
+            extractedDir.removeRecursively();
+        }
+    }
+
+    qDebug() << "UTF-8 decompression tests completed successfully";
+}

--- a/qztest/testutf8_decompress.cpp
+++ b/qztest/testutf8_decompress.cpp
@@ -92,7 +92,7 @@ void TestUtf8Decompress::decompressUtf8Files()
     }
 
     // Find artifact directories containing UTF-8 archives
-    QString pattern = QString("utf8_archives_qt*");
+    QString pattern = QString("utf8_%1_qt*").arg(archiveType);
     QDirIterator it(QDir::currentPath(), QStringList() << pattern, QDir::Dirs, QDirIterator::Subdirectories);
 
     QVERIFY2(it.hasNext(), qPrintable(QString("No UTF-8 archive artifacts found matching: %1").arg(pattern)));
@@ -105,7 +105,7 @@ void TestUtf8Decompress::decompressUtf8Files()
 
         QDir dir(artifactDir.absoluteFilePath());
         // Look for archives matching the type we're testing
-        QString zipPattern = QString("%1_*.zip").arg(archiveType);
+        QString zipPattern = QString("utf8_%1_*.zip").arg(archiveType);
         QStringList zipFiles = dir.entryList(QStringList() << zipPattern, QDir::Files);
 
         QVERIFY2(!zipFiles.isEmpty(), qPrintable(QString("No UTF-8 zip files found in artifact directory: %1").arg(artifactDir.fileName())));

--- a/qztest/testutf8_decompress.cpp
+++ b/qztest/testutf8_decompress.cpp
@@ -26,6 +26,7 @@ See COPYING file for the full LGPL text.
 #include <QtCore/QDir>
 #include <QtCore/QDirIterator>
 #include <QtCore/QFileInfo>
+#include <QtCore/QRegularExpression>
 #include <QtTest/QTest>
 
 #include <JlCompress.h>
@@ -79,11 +80,26 @@ void TestUtf8Decompress::decompressUtf8Files()
             QVERIFY2(!extractedFiles.isEmpty(), qPrintable(QString("No files found after extraction from: %1").arg(archiveFile)));
 
             // In C locale, UTF-8 filenames should be mangled (not properly decoded)
-            // We just verify that extraction doesn't crash and produces some output
+            // The behavior differs by platform when extracting UTF-8 filenames:
+            // - Windows: Unmappable characters are replaced with '?' (0x3f)
+            // - Linux: Unmappable characters are dropped entirely (null truncation)
             for (const QString &extractedFile : extractedFiles) {
                 QString filePath = extractedDir.absoluteFilePath(extractedFile);
                 QVERIFY2(QFile::exists(filePath), qPrintable(QString("Extracted file does not exist: %1").arg(filePath)));
                 qDebug() << "Found extracted file (possibly mangled):" << extractedFile;
+
+#ifdef Q_OS_WIN
+                // On Windows, expect '?' replacement: one or more '?' followed by .txt
+                // Example: "файл.txt" -> "????.txt"
+                QRegularExpression windowsPattern("^\\?+\\.txt$");
+                QVERIFY2(windowsPattern.match(extractedFile).hasMatch(),
+                         qPrintable(QString("Windows should produce pattern '?+.txt', got: %1").arg(extractedFile)));
+#else
+                // On Linux with non-UTF-8 locale, unmappable characters are dropped
+                // This results in just ".txt" (null truncation)
+                // Example: "файл.txt" -> ".txt"
+                QCOMPARE(extractedFile, QString(".txt"));
+#endif
             }
 
             // Cleanup

--- a/qztest/testutf8_decompress.cpp
+++ b/qztest/testutf8_decompress.cpp
@@ -62,34 +62,44 @@ void TestUtf8Decompress::decompressUtf8Files()
     QString archiveType = archiveTypeEnv.isEmpty() ? "with_flag" : QString::fromLatin1(archiveTypeEnv);
     qDebug() << "Testing archive type:" << archiveType;
 
-    // Determine expected behavior based on archive type, Qt version, and locale
+    // Determine expected behavior based on archive type, Qt version, platform, and locale
     bool shouldWork = false;
-    if (archiveType == "with_flag") {
-        // UTF-8 flag is set in archive: should always work
-        shouldWork = true;
-        qDebug() << "Expected: UTF-8 filenames should be decoded correctly (flag is set)";
-    } else {
-        // No UTF-8 flag: depends on platform/Qt version/locale
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-        shouldWork = true;  // Qt 6 forces UTF-8
-        qDebug() << "Expected: UTF-8 filenames should work (Qt 6 forces UTF-8)";
-#else
-        // Qt 5: depends on locale
-        QByteArray locale = qgetenv("LC_ALL");
-        if (locale.isEmpty()) locale = qgetenv("LANG");
-        shouldWork = locale.contains("UTF-8") || locale.contains("utf8");
-        if (shouldWork) {
-            qDebug() << "Expected: UTF-8 filenames should work (locale is UTF-8)";
-        } else {
-            qDebug() << "Expected: UTF-8 filenames will be mangled (Qt 5 + non-UTF-8 locale)";
+
 #ifdef Q_OS_WIN
-            qDebug() << "  Windows: expecting '?' replacement";
-#else
-            qDebug() << "  Linux: expecting null truncation (.txt)";
-#endif
-        }
-#endif
+    // Windows: Has codepage issues regardless of Qt version
+    // UTF-8 filenames only work if the UTF-8 flag is set in the archive
+    if (archiveType == "with_flag") {
+        shouldWork = true;
+        qDebug() << "Expected: UTF-8 filenames should work (Windows + UTF-8 flag set)";
+    } else {
+        shouldWork = false;
+        qDebug() << "Expected: UTF-8 filenames will be mangled (Windows + no UTF-8 flag)";
+        qDebug() << "  Windows: double-encoding or codepage issues";
     }
+#else
+    // Linux/Unix: Qt 6 forces UTF-8, Qt 5 depends on locale
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    // Qt 6 forces UTF-8 encoding regardless of flag or locale
+    shouldWork = true;
+    qDebug() << "Expected: UTF-8 filenames should work (Qt 6 forces UTF-8)";
+#else
+    // Qt 5: depends on locale, even with UTF-8 flag
+    // The UTF-8 flag in the archive is not sufficient on Qt 5 if locale is non-UTF-8
+    QByteArray locale = qgetenv("LC_ALL");
+    if (locale.isEmpty()) locale = qgetenv("LANG");
+    shouldWork = locale.contains("UTF-8") || locale.contains("utf8");
+
+    if (shouldWork) {
+        qDebug() << "Expected: UTF-8 filenames should work (Qt 5 + UTF-8 locale)";
+    } else {
+        qDebug() << "Expected: UTF-8 filenames will be mangled (Qt 5 + non-UTF-8 locale)";
+        if (archiveType == "with_flag") {
+            qDebug() << "  Note: UTF-8 flag is set but Qt 5 still requires UTF-8 locale";
+        }
+        qDebug() << "  Linux: expecting null truncation (.txt)";
+    }
+#endif
+#endif
 
     // Find artifact directories containing UTF-8 archives
     QString pattern = QString("utf8_%1_qt*").arg(archiveType);
@@ -144,19 +154,19 @@ void TestUtf8Decompress::decompressUtf8Files()
                 // Verify extracted filename matches one of the expected UTF-8 filenames
                 QVERIFY2(expectedUtf8Files.contains(extractedFile),
                          qPrintable(QString("Expected one of the UTF-8 filenames, got: %1").arg(extractedFile)));
-                qDebug() << "  ✓ UTF-8 filename correctly decoded:" << extractedFile;
+                qDebug() << "  UTF-8 filename correctly decoded:" << extractedFile;
             } else {
                 // Filenames should be mangled
 #ifdef Q_OS_WIN
-                // Windows: expect '?' replacement
-                QRegularExpression windowsPattern("^\\?+\\.txt$");
-                QVERIFY2(windowsPattern.match(extractedFile).hasMatch(),
-                         qPrintable(QString("Windows should produce '?+.txt', got: %1").arg(extractedFile)));
-                qDebug() << "  ✓ Windows: '?' replacement as expected";
+                // Windows: behavior varies - may produce '?' replacement, double-encoding, or other mangling
+                // Just verify it doesn't match the expected UTF-8 filenames
+                QVERIFY2(!expectedUtf8Files.contains(extractedFile),
+                         qPrintable(QString("Expected mangled filename on Windows, but got valid UTF-8: %1").arg(extractedFile)));
+                qDebug() << "  Windows: filename mangled as expected (got:" << extractedFile << ")";
 #else
                 // Linux Qt 5 + non-UTF-8 locale: expect null truncation
                 QCOMPARE(extractedFile, QString(".txt"));
-                qDebug() << "  ✓ Linux: null truncation as expected";
+                qDebug() << "  Linux: null truncation as expected";
 #endif
             }
 

--- a/qztest/testutf8_decompress.cpp
+++ b/qztest/testutf8_decompress.cpp
@@ -41,7 +41,7 @@ See COPYING file for the full LGPL text.
  *   - Qt 6: Works (Qt forces UTF-8)
  *   - Qt 5 + UTF-8 locale: Works (locale encoding matches file bytes)
  *   - Qt 5 + non-UTF-8 locale: Fails with mangling (encoding mismatch)
- *     - Windows: '?' replacement
+ *     - Windows: double encoded
  *     - Linux: null truncation
  */
 void TestUtf8Decompress::decompressUtf8Files()

--- a/qztest/testutf8_decompress.cpp
+++ b/qztest/testutf8_decompress.cpp
@@ -32,19 +32,70 @@ See COPYING file for the full LGPL text.
 #include <JlCompress.h>
 
 /*
- * The purpose of this test is to extract UTF-8 archives created in a UTF-8 locale
- * but extracted in a C locale environment. We expect the filenames to be mangled
- * (not properly decoded as UTF-8) since we're in a C locale.
+ * The purpose of this test is to extract UTF-8 archives and verify behavior
+ * based on archive type (with/without UTF-8 flag), platform, Qt version, and locale.
+ *
+ * Expected behavior:
+ * - Archives WITH UTF-8 flag: Should always work (flag tells us to decode as UTF-8)
+ * - Archives WITHOUT UTF-8 flag:
+ *   - Qt 6: Works (Qt forces UTF-8)
+ *   - Qt 5 + UTF-8 locale: Works (locale encoding matches file bytes)
+ *   - Qt 5 + non-UTF-8 locale: Fails with mangling (encoding mismatch)
+ *     - Windows: '?' replacement
+ *     - Linux: null truncation
  */
 void TestUtf8Decompress::decompressUtf8Files()
 {
     qDebug() << "Performing UTF-8 decompress tests in " << QDir::currentPath();
     qDebug() << "Current locale: LC_ALL=" << qgetenv("LC_ALL") << "LANG=" << qgetenv("LANG");
 
-    // Find artifact directories containing UTF-8 archives
-    QDirIterator it(QDir::currentPath(), QStringList() << "utf8_archives_*", QDir::Dirs, QDirIterator::Subdirectories);
+    // Expected UTF-8 filenames (must match testutf8_compress.cpp)
+    QStringList expectedUtf8Files;
+    expectedUtf8Files << QString::fromUtf8("файл.txt");        // Cyrillic
+    expectedUtf8Files << QString::fromUtf8("ありがとう.txt");    // Japanese
+    expectedUtf8Files << QString::fromUtf8("你好.txt");         // Chinese
+    expectedUtf8Files << QString::fromUtf8("Привет.txt");      // Cyrillic
+    expectedUtf8Files << QString::fromUtf8("测试.txt");         // Chinese
 
-    QVERIFY2(it.hasNext(), "No UTF-8 archive artifacts found");
+    // Determine archive type being tested
+    QByteArray archiveTypeEnv = qgetenv("TEST_UTF8_ARCHIVE_TYPE");
+    QString archiveType = archiveTypeEnv.isEmpty() ? "with_flag" : QString::fromLatin1(archiveTypeEnv);
+    qDebug() << "Testing archive type:" << archiveType;
+
+    // Determine expected behavior based on archive type, Qt version, and locale
+    bool shouldWork = false;
+    if (archiveType == "with_flag") {
+        // UTF-8 flag is set in archive: should always work
+        shouldWork = true;
+        qDebug() << "Expected: UTF-8 filenames should be decoded correctly (flag is set)";
+    } else {
+        // No UTF-8 flag: depends on platform/Qt version/locale
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+        shouldWork = true;  // Qt 6 forces UTF-8
+        qDebug() << "Expected: UTF-8 filenames should work (Qt 6 forces UTF-8)";
+#else
+        // Qt 5: depends on locale
+        QByteArray locale = qgetenv("LC_ALL");
+        if (locale.isEmpty()) locale = qgetenv("LANG");
+        shouldWork = locale.contains("UTF-8") || locale.contains("utf8");
+        if (shouldWork) {
+            qDebug() << "Expected: UTF-8 filenames should work (locale is UTF-8)";
+        } else {
+            qDebug() << "Expected: UTF-8 filenames will be mangled (Qt 5 + non-UTF-8 locale)";
+#ifdef Q_OS_WIN
+            qDebug() << "  Windows: expecting '?' replacement";
+#else
+            qDebug() << "  Linux: expecting null truncation (.txt)";
+#endif
+        }
+#endif
+    }
+
+    // Find artifact directories containing UTF-8 archives
+    QString pattern = QString("utf8_archives_qt*");
+    QDirIterator it(QDir::currentPath(), QStringList() << pattern, QDir::Dirs, QDirIterator::Subdirectories);
+
+    QVERIFY2(it.hasNext(), qPrintable(QString("No UTF-8 archive artifacts found matching: %1").arg(pattern)));
 
     int totalArchivesProcessed = 0;
 
@@ -53,7 +104,9 @@ void TestUtf8Decompress::decompressUtf8Files()
         qDebug() << "====== Found artifact:" << artifactDir.fileName() << "======";
 
         QDir dir(artifactDir.absoluteFilePath());
-        QStringList zipFiles = dir.entryList(QStringList() << "utf8_*.zip", QDir::Files);
+        // Look for archives matching the type we're testing
+        QString zipPattern = QString("%1_*.zip").arg(archiveType);
+        QStringList zipFiles = dir.entryList(QStringList() << zipPattern, QDir::Files);
 
         QVERIFY2(!zipFiles.isEmpty(), qPrintable(QString("No UTF-8 zip files found in artifact directory: %1").arg(artifactDir.fileName())));
 
@@ -79,26 +132,31 @@ void TestUtf8Decompress::decompressUtf8Files()
             QStringList extractedFiles = extractedDir.entryList(QDir::Files | QDir::Hidden);
             QVERIFY2(!extractedFiles.isEmpty(), qPrintable(QString("No files found after extraction from: %1").arg(archiveFile)));
 
-            // In C locale, UTF-8 filenames should be mangled (not properly decoded)
-            // The behavior differs by platform when extracting UTF-8 filenames:
-            // - Windows: Unmappable characters are replaced with '?' (0x3f)
-            // - Linux: Unmappable characters are dropped entirely (null truncation)
-            for (const QString &extractedFile : extractedFiles) {
-                QString filePath = extractedDir.absoluteFilePath(extractedFile);
-                QVERIFY2(QFile::exists(filePath), qPrintable(QString("Extracted file does not exist: %1").arg(filePath)));
-                qDebug() << "Found extracted file (possibly mangled):" << extractedFile;
+            // Verify extracted filenames based on expected behavior
+            QCOMPARE(extractedFiles.size(), 1);  // Each archive contains exactly one file
+            QString extractedFile = extractedFiles.first();
+            QString filePath = extractedDir.absoluteFilePath(extractedFile);
+            QVERIFY2(QFile::exists(filePath), qPrintable(QString("Extracted file does not exist: %1").arg(filePath)));
+            qDebug() << "Extracted file:" << extractedFile << "(" << extractedFile.toUtf8().toHex() << ")";
 
+            if (shouldWork) {
+                // Filenames should be correctly decoded as UTF-8
+                // Verify extracted filename matches one of the expected UTF-8 filenames
+                QVERIFY2(expectedUtf8Files.contains(extractedFile),
+                         qPrintable(QString("Expected one of the UTF-8 filenames, got: %1").arg(extractedFile)));
+                qDebug() << "  ✓ UTF-8 filename correctly decoded:" << extractedFile;
+            } else {
+                // Filenames should be mangled
 #ifdef Q_OS_WIN
-                // On Windows, expect '?' replacement: one or more '?' followed by .txt
-                // Example: "файл.txt" -> "????.txt"
+                // Windows: expect '?' replacement
                 QRegularExpression windowsPattern("^\\?+\\.txt$");
                 QVERIFY2(windowsPattern.match(extractedFile).hasMatch(),
-                         qPrintable(QString("Windows should produce pattern '?+.txt', got: %1").arg(extractedFile)));
+                         qPrintable(QString("Windows should produce '?+.txt', got: %1").arg(extractedFile)));
+                qDebug() << "  ✓ Windows: '?' replacement as expected";
 #else
-                // On Linux with non-UTF-8 locale, unmappable characters are dropped
-                // This results in just ".txt" (null truncation)
-                // Example: "файл.txt" -> ".txt"
+                // Linux Qt 5 + non-UTF-8 locale: expect null truncation
                 QCOMPARE(extractedFile, QString(".txt"));
+                qDebug() << "  ✓ Linux: null truncation as expected";
 #endif
             }
 

--- a/qztest/testutf8_decompress.h
+++ b/qztest/testutf8_decompress.h
@@ -1,0 +1,33 @@
+#ifndef QUAZIP_TEST_UTF8_DECOMPRESS_H
+#define QUAZIP_TEST_UTF8_DECOMPRESS_H
+
+/*
+Copyright (C) 2025 cen1
+
+This file is part of QuaZip test suite.
+
+QuaZip is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 2.1 of the License, or
+(at your option) any later version.
+
+QuaZip is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with QuaZip.  If not, see <http://www.gnu.org/licenses/>.
+
+See COPYING file for the full LGPL text.
+*/
+
+#include <QtCore/QObject>
+
+class TestUtf8Decompress: public QObject {
+    Q_OBJECT
+private slots:
+    void decompressUtf8Files();
+};
+
+#endif // QUAZIP_TEST_UTF8_DECOMPRESS_H


### PR DESCRIPTION
Initial attempt to address #114 

Two issues to resolve
1. `zip.setUtf8Enabled` needs to be called before `QuaZip::open` to have any effect. Some JlCompress methods have `QuaZip* zip` as an input so passing a different Option there makes no difference. It could confuse someone who would expect this to be set either way, not the best API..

2. Current integration tests do not really seem to test UTF-8 support (at least on Linux). Whether UTF-8 is enabled or not, the  tests pass (see for example `TestQuaZipFile::zipUnzip()`, changing the flag makes no difference). Need to investigate why that is and test for negative example.