### PR TITLE
Fix test hashes when using zlib-ng

### DIFF
--- a/.github/workflows/zlib-ng.yml
+++ b/.github/workflows/zlib-ng.yml
@@ -1,0 +1,31 @@
+on:
+  push:
+    branches:
+      - master
+      - feature/*
+  pull_request:
+
+name: fedora-zlib-ng
+permissions: read-all
+
+jobs:
+  fedora:
+    if: true
+    name: "${{ matrix.qt_version }} on ${{ matrix.runner }}"
+    runs-on: "ubuntu-22.04"
+    container:
+      image: "${{ matrix.runner }}"
+    strategy:
+      matrix:
+        runner:
+          - "fedora:42"
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install build tools
+        run: dnf install g++ make cmake qt6-qtbase-devel qt6-qt5compat-devel zlib-ng
+      - name: Run cmake
+        run: cmake -B build -DQUAZIP_ENABLE_TESTS=ON
+      - name: Build quazip
+        run: cd build && VERBOSE=1 make -j8
+      - name: Run tests
+        run: build/qztest/qztest

--- a/.github/workflows/zlib-ng.yml
+++ b/.github/workflows/zlib-ng.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install build tools
-        run: dnf -y install g++ make cmake qt6-qtbase-devel qt6-qt5compat-devel zlib-ng
+        run: dnf -y install g++ make cmake qt6-qtbase-devel qt6-qt5compat-devel zlib-ng-devel zlib-ng-compat-devel
       - name: Run cmake
         run: cmake -B build -DQUAZIP_ENABLE_TESTS=ON
       - name: Build quazip

--- a/.github/workflows/zlib-ng.yml
+++ b/.github/workflows/zlib-ng.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install build tools
-        run: dnf install g++ make cmake qt6-qtbase-devel qt6-qt5compat-devel zlib-ng
+        run: dnf -y install g++ make cmake qt6-qtbase-devel qt6-qt5compat-devel zlib-ng
       - name: Run cmake
         run: cmake -B build -DQUAZIP_ENABLE_TESTS=ON
       - name: Build quazip

--- a/qztest/testjlcompress.cpp
+++ b/qztest/testjlcompress.cpp
@@ -98,17 +98,20 @@ void TestJlCompress::compressFileOptions_data()
                                     << QDateTime(QDate(2024, 9, 19), QTime(21, 0, 0), QTimeZone::utc())
                                     << JlCompress::Options::Storage
                                     << ""
+                                    << ""
                                     << "";
     QTest::newRow("simple-fastest") << "jlsimplefile-fastest.zip"
                                     << "test0.txt"
                                     << QDateTime(QDate(2024, 9, 19), QTime(21, 0, 0), QTimeZone::utc())
                                     << JlCompress::Options::Fastest
                                     << ""
+                                    << ""
                                     << "";
     QTest::newRow("simple-faster") << "jlsimplefile-faster.zip"
                                    << "test0.txt"
                                    << QDateTime(QDate(2024, 9, 19), QTime(21, 0, 0), QTimeZone::utc())
                                    << JlCompress::Options::Faster
+                                   << ""
                                    << ""
                                    << "";
     QTest::newRow("simple-standard") << "jlsimplefile-standard.zip"
@@ -123,11 +126,13 @@ void TestJlCompress::compressFileOptions_data()
                                    << QDateTime(QDate(2024, 9, 19), QTime(21, 0, 0), QTimeZone::utc())
                                    << JlCompress::Options::Better
                                    << ""
+                                   << ""
                                    << "";
     QTest::newRow("simple-best") << "jlsimplefile-best.zip"
                                  << "test0.txt"
                                  << QDateTime(QDate(2024, 9, 19), QTime(21, 0, 0), QTimeZone::utc())
                                  << JlCompress::Options::Best
+                                 << ""
                                  << ""
                                  << "";
 }
@@ -298,6 +303,7 @@ void TestJlCompress::compressDirOptions_data()
                                     << QDateTime(QDate(2024, 9, 19), QTime(21, 0, 0), QTimeZone::utc())
                                     << JlCompress::Options::Storage
                                     << ""
+                                    << ""
                                     << "";
     QTest::newRow("simple-fastest") << "jldir-fastest.zip"
                                     << (QStringList() << "test0.txt" << "testdir1/test1.txt"
@@ -309,6 +315,7 @@ void TestJlCompress::compressDirOptions_data()
                                     << QDateTime(QDate(2024, 9, 19), QTime(21, 0, 0), QTimeZone::utc())
                                     << JlCompress::Options::Fastest
                                     << ""
+                                    << ""
                                     << "";
     QTest::newRow("simple-faster") << "jldir-faster.zip"
                                     << (QStringList() << "test0.txt" << "testdir1/test1.txt"
@@ -319,6 +326,7 @@ void TestJlCompress::compressDirOptions_data()
                                                       << "testdir2/subdir/" << "testdir2/subdir/test2sub.txt")
                                     << QDateTime(QDate(2024, 9, 19), QTime(21, 0, 0), QTimeZone::utc())
                                     << JlCompress::Options::Faster
+                                    << ""
                                     << ""
                                     << "";
     QTest::newRow("simple-standard") << "jldir-standard.zip"
@@ -343,6 +351,7 @@ void TestJlCompress::compressDirOptions_data()
                                     << QDateTime(QDate(2024, 9, 19), QTime(21, 0, 0), QTimeZone::utc())
                                     << JlCompress::Options::Better
                                     << ""
+                                    << ""
                                     << "";
     QTest::newRow("simple-best") << "jldir-best.zip"
                                     << (QStringList() << "test0.txt" << "testdir1/test1.txt"
@@ -353,6 +362,7 @@ void TestJlCompress::compressDirOptions_data()
                                                       << "testdir2/subdir/" << "testdir2/subdir/test2sub.txt")
                                     << QDateTime(QDate(2024, 9, 19), QTime(21, 0, 0), QTimeZone::utc())
                                     << JlCompress::Options::Best
+                                    << ""
                                     << ""
                                     << "";
 }

--- a/qztest/testjlcompress.cpp
+++ b/qztest/testjlcompress.cpp
@@ -84,12 +84,14 @@ void TestJlCompress::compressFileOptions_data()
     QTest::addColumn<QDateTime>("dateTime");
     QTest::addColumn<JlCompress::Options::CompressionStrategy>("strategy");
     QTest::addColumn<QString>("sha256sum_unix"); // Due to extra data archives are not identical
+    QTest::addColumn<QString>("sha256sum_unix_ng"); // zlib-ng
     QTest::addColumn<QString>("sha256sum_win");
     QTest::newRow("simple") << "jlsimplefile.zip"
                             << "test0.txt"
                             << QDateTime(QDate(2024, 9, 19), QTime(21, 0, 0), QTimeZone::utc())
                             << JlCompress::Options::Default
                             << "5eedd83aee92cf3381155d167fee54a4ef6e43b8bc7a979c903611d9aa28610a"
+                            << "752db50b15db1a19e091f9c1b43ec22b279867b20d43c76bc9a01d7bc0d7ae4f"
                             << "cb1847dff1a5c33a805efde2558fc74024ad4c64c8607f8b12903e4d92385955";
     QTest::newRow("simple-storage") << "jlsimplefile-storage.zip"
                                     << "test0.txt"
@@ -114,6 +116,7 @@ void TestJlCompress::compressFileOptions_data()
                                      << QDateTime(QDate(2024, 9, 19), QTime(21, 0, 0), QTimeZone::utc())
                                      << JlCompress::Options::Standard
                                      << "5eedd83aee92cf3381155d167fee54a4ef6e43b8bc7a979c903611d9aa28610a"
+                                     << "752db50b15db1a19e091f9c1b43ec22b279867b20d43c76bc9a01d7bc0d7ae4f"
                                      << "cb1847dff1a5c33a805efde2558fc74024ad4c64c8607f8b12903e4d92385955";
     QTest::newRow("simple-better") << "jlsimplefile-better.zip"
                                    << "test0.txt"
@@ -136,6 +139,7 @@ void TestJlCompress::compressFileOptions()
     QFETCH(QDateTime, dateTime);
     QFETCH(JlCompress::Options::CompressionStrategy, strategy);
     QFETCH(QString, sha256sum_unix);
+    QFETCH(QString, sha256sum_unix_ng);
     QFETCH(QString, sha256sum_win);
     QDir curDir;
     if (curDir.exists(zipName)) {
@@ -161,11 +165,13 @@ void TestJlCompress::compressFileOptions()
     // Hash is computed on the resulting file externally, then hardcoded in the test data
     // This should help detecting any library breakage since we compare against a well-known stable result
     QString hash = QCryptographicHash::hash(zipFile.readAll(), QCryptographicHash::Sha256).toHex();
-    #ifdef Q_OS_WIN
+#if defined Q_OS_WIN
     if (!sha256sum_win.isEmpty()) QCOMPARE(hash, sha256sum_win);
-    #else
+#elif defined ZLIBNG_VERSION
+    if (!sha256sum_unix_ng.isEmpty()) QCOMPARE(hash, sha256sum_unix_ng);
+#else
     if (!sha256sum_unix.isEmpty()) QCOMPARE(hash, sha256sum_unix);
-    #endif
+#endif
     zipFile.close();
     removeTestFiles(QStringList() << fileName);
     curDir.remove(zipName);
@@ -268,6 +274,7 @@ void TestJlCompress::compressDirOptions_data()
     QTest::addColumn<QDateTime>("dateTime");
     QTest::addColumn<JlCompress::Options::CompressionStrategy>("strategy");
     QTest::addColumn<QString>("sha256sum_unix");
+    QTest::addColumn<QString>("sha256sum_unix_ng");
     QTest::addColumn<QString>("sha256sum_win");
     QTest::newRow("simple") << "jldir.zip"
                             << (QStringList() << "test0.txt" << "testdir1/test1.txt"
@@ -279,6 +286,7 @@ void TestJlCompress::compressDirOptions_data()
                             << QDateTime(QDate(2024, 9, 19), QTime(21, 0, 0), QTimeZone::utc())
                             << JlCompress::Options::Default
                             << "ed0d5921b2fc11b6b4cb214b3e43ea3ea28987d6ff8080faab54c4756de30af6"
+                            << "299cd566069754a4ca1deb025e279be3cca80e454132b51fa2a22e41c8ef1299"
                             << "1eba110a33718c07a4ddf3fa515d1b4c6e3f4fc912b2e29e5e32783e2cddf852";
     QTest::newRow("simple-storage") << "jldir-storage.zip"
                                     << (QStringList() << "test0.txt" << "testdir1/test1.txt"
@@ -323,6 +331,7 @@ void TestJlCompress::compressDirOptions_data()
                                     << QDateTime(QDate(2024, 9, 19), QTime(21, 0, 0), QTimeZone::utc())
                                     << JlCompress::Options::Standard
                                     << "ed0d5921b2fc11b6b4cb214b3e43ea3ea28987d6ff8080faab54c4756de30af6"
+                                    << "299cd566069754a4ca1deb025e279be3cca80e454132b51fa2a22e41c8ef1299"
                                     << "1eba110a33718c07a4ddf3fa515d1b4c6e3f4fc912b2e29e5e32783e2cddf852";
     QTest::newRow("simple-better") << "jldir-better.zip"
                                     << (QStringList() << "test0.txt" << "testdir1/test1.txt"
@@ -356,6 +365,7 @@ void TestJlCompress::compressDirOptions()
     QFETCH(QDateTime, dateTime);
     QFETCH(JlCompress::Options::CompressionStrategy, strategy);
     QFETCH(QString, sha256sum_unix);
+    QFETCH(QString, sha256sum_unix_ng);
     QFETCH(QString, sha256sum_win);
     QDir curDir;
     if (curDir.exists(zipName)) {
@@ -388,6 +398,8 @@ void TestJlCompress::compressDirOptions()
     QString hash = QCryptographicHash::hash(zipFile.readAll(), QCryptographicHash::Sha256).toHex();
 #ifdef Q_OS_WIN
     if (!sha256sum_win.isEmpty()) QCOMPARE(hash, sha256sum_win);
+#elif defined ZLIBNG_VERSION
+    if (!sha256sum_unix_ng.isEmpty()) QCOMPARE(hash, sha256sum_unix_ng);
 #else
     if (!sha256sum_unix.isEmpty()) QCOMPARE(hash, sha256sum_unix);
 #endif


### PR DESCRIPTION
zlib-ng is used by default on some distros like Fedora. It is ABI compatible with zlib but produces different final zip content. Introduce additional hashes in tests to cover this case.