### PR TITLE
[cmake] Use FetchContent_MakeAvailable

### DIFF
--- a/cmake/clone-repo.cmake
+++ b/cmake/clone-repo.cmake
@@ -26,7 +26,7 @@ macro(clone_repo name url)
         FetchContent_GetProperties(${name} POPULATED ${name_lower}_POPULATED)
 
         if(NOT ${name_lower}_POPULATED)
-            FetchContent_Populate(${name})
+            FetchContent_MakeAvailable(${name})
         endif()
 
         set(${name_upper}_SOURCE_DIR ${${name_lower}_SOURCE_DIR})


### PR DESCRIPTION
Populate is deprecated, and in fact appears to completely not work on GitHub's
Windows runner, not sure why, but I confirmed that this fixed it.

Signed-off-by: crueter <crueter@eden-emu.dev>
