### PR TITLE
Refresh macos workers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,11 +64,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os_version: [14, 13]
-        qt_version: [5.15.2, 6.8.2]
+        os_version: [15, 14, macos-15-intel]
+        qt_version: [6.8.2, 5.15.2]
         shared: [ON, OFF]
         exclude:
           - os_version: 14
+            qt_version: 5.15.2 #Not available on macos-14 due to ARM arch
+          - os_version: 15
             qt_version: 5.15.2 #Not available on macos-14 due to ARM arch
     uses: ./.github/workflows/reusable.yml
     with:
@@ -170,7 +172,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os_version: [ 14 ]
+        os_version: [ 15 ]
         qt_version: [ 6.8.2 ]
         shared: [ ON ]
     uses: ./.github/workflows/reusable.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,9 +69,9 @@ jobs:
         shared: [ON, OFF]
         exclude:
           - os_version: 14
-            qt_version: 5.15.2 #Not available on macos-14 due to ARM arch
+            qt_version: 5.15.2 #Not available due to ARM arch
           - os_version: 15
-            qt_version: 5.15.2 #Not available on macos-14 due to ARM arch
+            qt_version: 5.15.2 #Not available due to ARM arch
     uses: ./.github/workflows/reusable.yml
     with:
       runs_on: macos-${{ matrix.os_version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os_version: [15, 14, macos-15-intel]
+        os_version: [15, 14, 15-intel]
         qt_version: [6.8.2, 5.15.2]
         shared: [ON, OFF]
         exclude:


### PR DESCRIPTION
macos-13 is deprecated in December, move to 14 and 15.