### PR TITLE
clang-tidy and clazy suggestions.

### DIFF
--- a/quazip/JlCompress.cpp
+++ b/quazip/JlCompress.cpp
@@ -120,7 +120,7 @@ bool JlCompress::compressSubDir(QuaZip* zip, QString dir, QString origDir, bool 
     // Whether to compress the subfolders, recursion
     if (recursive) {
         // For each subfolder
-        QFileInfoList files = directory.entryInfoList(QDir::AllDirs|QDir::NoDotAndDotDot|filters);
+        const QFileInfoList files = directory.entryInfoList(QDir::AllDirs|QDir::NoDotAndDotDot|filters);
         for (const auto& file : files) {
             if (!file.isDir()) // needed for Qt < 4.7 because it doesn't understand AllDirs
                 continue;
@@ -130,7 +130,7 @@ bool JlCompress::compressSubDir(QuaZip* zip, QString dir, QString origDir, bool 
     }
 
     // For each file in directory
-    QFileInfoList files = directory.entryInfoList(QDir::Files|filters);
+    const QFileInfoList files = directory.entryInfoList(QDir::Files|filters);
     for (const auto& file : files) {
         // If it's not a file or it's the compressed file being created
         if(!file.isFile()||file.absoluteFilePath()==zip->getZipName()) continue;
@@ -406,21 +406,21 @@ QString JlCompress::extractFile(QString fileCompressed, QString fileName, QStrin
 QString JlCompress::extractFile(QuaZip &zip, QString fileName, QString fileDest)
 {
     if(!zip.open(QuaZip::mdUnzip)) {
-        return QString();
+        return {};
     }
 
     // Extract file
     if (fileDest.isEmpty())
         fileDest = fileName;
     if (!extractFile(&zip,fileName,fileDest)) {
-        return QString();
+        return {};
     }
 
     // Close zip
     zip.close();
     if(zip.getZipError()!=0) {
         removeFile(QStringList(fileDest));
-        return QString();
+        return {};
     }
     return QFileInfo(fileDest).absoluteFilePath();
 }
@@ -434,7 +434,7 @@ QStringList JlCompress::extractFiles(QString fileCompressed, QStringList files, 
 QStringList JlCompress::extractFiles(QuaZip &zip, const QStringList &files, const QString &dir)
 {
     if(!zip.open(QuaZip::mdUnzip)) {
-        return QStringList();
+        return {};
     }
 
     // Extract file
@@ -443,7 +443,7 @@ QStringList JlCompress::extractFiles(QuaZip &zip, const QStringList &files, cons
         QString absPath = QDir(dir).absoluteFilePath(files.at(i));
         if (!extractFile(&zip, files.at(i), absPath)) {
             removeFile(extracted);
-            return QStringList();
+            return {};
         }
         extracted.append(absPath);
     }
@@ -452,7 +452,7 @@ QStringList JlCompress::extractFiles(QuaZip &zip, const QStringList &files, cons
     zip.close();
     if(zip.getZipError()!=0) {
         removeFile(extracted);
-        return QStringList();
+        return {};
     }
 
     return extracted;
@@ -473,7 +473,7 @@ QStringList JlCompress::extractDir(QString fileCompressed, QString dir) {
 QStringList JlCompress::extractDir(QuaZip &zip, const QString &dir)
 {
     if(!zip.open(QuaZip::mdUnzip)) {
-        return QStringList();
+        return {};
     }
     QString cleanDir = QDir::cleanPath(dir);
     QDir directory(cleanDir);
@@ -482,7 +482,7 @@ QStringList JlCompress::extractDir(QuaZip &zip, const QString &dir)
         absCleanDir += QLatin1Char('/');
     QStringList extracted;
     if (!zip.goToFirstFile()) {
-        return QStringList();
+        return {};
     }
     do {
         QString name = zip.getCurrentFileName();
@@ -492,7 +492,7 @@ QStringList JlCompress::extractDir(QuaZip &zip, const QString &dir)
             continue;
         if (!extractFile(&zip, QLatin1String(""), absFilePath)) {
             removeFile(extracted);
-            return QStringList();
+            return {};
         }
         extracted.append(absFilePath);
     } while (zip.goToNextFile());
@@ -501,7 +501,7 @@ QStringList JlCompress::extractDir(QuaZip &zip, const QString &dir)
     zip.close();
     if(zip.getZipError()!=0) {
         removeFile(extracted);
-        return QStringList();
+        return {};
     }
 
     return extracted;
@@ -517,7 +517,7 @@ QStringList JlCompress::getFileList(QuaZip *zip)
 {
     if(!zip->open(QuaZip::mdUnzip)) {
         delete zip;
-        return QStringList();
+        return {};
     }
 
     // Extract file names
@@ -526,7 +526,7 @@ QStringList JlCompress::getFileList(QuaZip *zip)
     for(bool more=zip->goToFirstFile(); more; more=zip->goToNextFile()) {
       if(!zip->getCurrentFileInfo(&info)) {
           delete zip;
-          return QStringList();
+          return {};
       }
       lst << info.name;
       //info.name.toLocal8Bit().constData()
@@ -536,7 +536,7 @@ QStringList JlCompress::getFileList(QuaZip *zip)
     zip->close();
     if(zip->getZipError()!=0) {
         delete zip;
-        return QStringList();
+        return {};
     }
     delete zip;
     return lst;

--- a/quazip/JlCompress.h
+++ b/quazip/JlCompress.h
@@ -111,7 +111,7 @@ public:
         // If set, used as last modified on file inside the archive.
         // If compressing a directory, used for all files.
         QDateTime m_dateTime;
-        CompressionStrategy m_compressionStrategy;
+        CompressionStrategy m_compressionStrategy{Default};
     };
 
     static bool copyData(QIODevice &inFile, QIODevice &outFile);
@@ -147,6 +147,8 @@ public:
       the root of the ZIP.
       \param recursive Whether to pack sub-directories as well or only
       files.
+      \param filters what to pack, filters are applied both when searching
+      for subdirs (if packing recursively) and when looking for files to pack
       \return true if success, false otherwise.
       */
     static bool compressSubDir(QuaZip* parentZip, QString dir, QString parentDir, bool recursive,
@@ -160,7 +162,7 @@ public:
       the root of the ZIP.
       \param recursive Whether to pack sub-directories as well or only
       \param filters what to pack, filters are applied both when searching
-* for subdirs (if packing recursively) and when looking for files to pack
+      for subdirs (if packing recursively) and when looking for files to pack
       \param options Options for fixed file timestamp, compression level, encryption..
       files.
       \return true if success, false otherwise.

--- a/quazip/quaadler32.h
+++ b/quazip/quaadler32.h
@@ -48,7 +48,7 @@ public:
 	quint32 value() override;
 
 private:
-	quint32 checksum;
+  quint32 checksum{};
 };
 
 #endif //QUAADLER32_H

--- a/quazip/quacrc32.h
+++ b/quazip/quacrc32.h
@@ -44,7 +44,7 @@ public:
 	quint32 value() override;
 
 private:
-	quint32 checksum;
+  quint32 checksum{};
 };
 
 #endif //QUACRC32_H

--- a/quazip/quagzipfile.cpp
+++ b/quazip/quagzipfile.cpp
@@ -31,10 +31,10 @@ see quazip/(un)zip.h files for details. Basically it's the zlib license.
 class QuaGzipFilePrivate {
     friend class QuaGzipFile;
     QString fileName;
-    gzFile gzd;
-    inline QuaGzipFilePrivate(): gzd(nullptr) {}
-    inline QuaGzipFilePrivate(const QString &_fileName):
-        fileName(_fileName), gzd(nullptr) {}
+    gzFile gzd{};
+    inline QuaGzipFilePrivate() {}
+    explicit inline QuaGzipFilePrivate(const QString &_fileName):
+        fileName(_fileName) {}
     template<typename FileId> bool open(FileId id, 
         QIODevice::OpenMode mode, QString &error);
     gzFile open(int fd, const char *modeString);

--- a/quazip/quagzipfile.h
+++ b/quazip/quagzipfile.h
@@ -100,7 +100,7 @@ private:
     // not implemented by design to disable copy
     QuaGzipFile(const QuaGzipFile &that);
     QuaGzipFile& operator=(const QuaGzipFile &that);
-    QuaGzipFilePrivate *d;
+    QuaGzipFilePrivate *d{};
 };
 
 #endif // QUAZIP_QUAGZIPFILE_H

--- a/quazip/quaziodevice.cpp
+++ b/quazip/quaziodevice.cpp
@@ -34,10 +34,11 @@ class QuaZIODevicePrivate {
     friend class QuaZIODevice;
     QuaZIODevicePrivate(QIODevice *io, QuaZIODevice *q);
     ~QuaZIODevicePrivate();
-    QIODevice *io;
-    QuaZIODevice *q;
-    z_stream zins;
-    z_stream zouts;
+    Q_DISABLE_COPY_MOVE(QuaZIODevicePrivate)
+    QIODevice *io{};
+    QuaZIODevice *q{};
+    z_stream zins{};
+    z_stream zouts{};
     char *inBuf{nullptr};
     int inBufPos{0};
     int inBufSize{0};
@@ -159,7 +160,7 @@ QuaZIODevice::QuaZIODevice(QIODevice *io, QObject *parent):
     QIODevice(parent),
     d(new QuaZIODevicePrivate(io, this))
 {
-  connect(io, SIGNAL(readyRead()), SIGNAL(readyRead()));
+  connect(io, &QIODevice::readyRead, &QIODevice::readyRead);
 }
 
 QuaZIODevice::~QuaZIODevice()

--- a/quazip/quaziodevice.h
+++ b/quazip/quaziodevice.h
@@ -96,6 +96,6 @@ protected:
   /// Implementation of QIODevice::writeData().
   qint64 writeData(const char *data, qint64 maxSize) override;
 private:
-  QuaZIODevicePrivate *d;
+  QuaZIODevicePrivate *d{};
 };
 #endif // QUAZIP_QUAZIODEVICE_H

--- a/quazip/quazip.cpp
+++ b/quazip/quazip.cpp
@@ -41,21 +41,22 @@ quazip/(un)zip.h files for details, basically it's zlib license.
 class QuaZipPrivate {
   friend class QuaZip;
   private:
-    Q_DISABLE_COPY(QuaZipPrivate)
+    ~QuaZipPrivate() = default;
+    Q_DISABLE_COPY_MOVE(QuaZipPrivate)
     /// The pointer to the corresponding QuaZip instance.
-    QuaZip *q;
+    QuaZip *q{};
     /// The codec for file names (used when UTF-8 is not enabled).
-    QuazipTextCodec *fileNameCodec;
+    QuazipTextCodec *fileNameCodec{};
     /// The codec for comments (used when UTF-8 is not enabled).
-    QuazipTextCodec *commentCodec;
+    QuazipTextCodec *commentCodec{};
     /// The archive file name.
     QString zipName;
     /// The device to access the archive.
-    QIODevice *ioDevice;
+    QIODevice *ioDevice{};
     /// The global comment.
     QString comment;
     /// The open mode.
-    QuaZip::Mode mode;
+    QuaZip::Mode mode{QuaZip::mdNotOpen};
     union {
       /// The internal handle for UNZIP modes.
       unzFile unzFile_f;
@@ -63,19 +64,19 @@ class QuaZipPrivate {
       zipFile zipFile_f;
     };
     /// Whether a current file is set.
-    bool hasCurrentFile_f;
+    bool hasCurrentFile_f{};
     /// The last error.
-    int zipError;
+    int zipError{UNZ_OK};
     /// Whether \ref QuaZip::setDataDescriptorWritingEnabled() "the data descriptor writing mode" is enabled.
-    bool dataDescriptorWritingEnabled;
+    bool dataDescriptorWritingEnabled{true};
     /// The zip64 mode.
-    bool zip64;
+    bool zip64{};
     /// The auto-close flag.
-    bool autoClose;
+    bool autoClose{true};
     /// The UTF-8 flag.
-    bool utf8;
+    bool utf8{};
     /// The OS code.
-    uint osCode;
+    uint osCode{};
     inline QuazipTextCodec *getDefaultFileNameCodec()
     {
         if (defaultFileNameCodec == nullptr) {
@@ -84,18 +85,10 @@ class QuaZipPrivate {
         return defaultFileNameCodec;
     }
     /// The constructor for the corresponding QuaZip constructor.
-    inline QuaZipPrivate(QuaZip *_q):
+    explicit inline QuaZipPrivate(QuaZip *_q):
       q(_q),
       fileNameCodec(getDefaultFileNameCodec()),
       commentCodec(QuazipTextCodec::codecForLocale()),
-      ioDevice(nullptr),
-      mode(QuaZip::mdNotOpen),
-      hasCurrentFile_f(false),
-      zipError(UNZ_OK),
-      dataDescriptorWritingEnabled(true),
-      zip64(false),
-      autoClose(true),
-      utf8(false),
       osCode(defaultOsCode)
     {
         unzFile_f = nullptr;
@@ -109,14 +102,6 @@ class QuaZipPrivate {
       fileNameCodec(getDefaultFileNameCodec()),
       commentCodec(QuazipTextCodec::codecForLocale()),
       zipName(_zipName),
-      ioDevice(nullptr),
-      mode(QuaZip::mdNotOpen),
-      hasCurrentFile_f(false),
-      zipError(UNZ_OK),
-      dataDescriptorWritingEnabled(true),
-      zip64(false),
-      autoClose(true),
-      utf8(false),
       osCode(defaultOsCode)
     {
         unzFile_f = nullptr;
@@ -130,13 +115,6 @@ class QuaZipPrivate {
       fileNameCodec(getDefaultFileNameCodec()),
       commentCodec(QuazipTextCodec::codecForLocale()),
       ioDevice(_ioDevice),
-      mode(QuaZip::mdNotOpen),
-      hasCurrentFile_f(false),
-      zipError(UNZ_OK),
-      dataDescriptorWritingEnabled(true),
-      zip64(false),
-      autoClose(true),
-      utf8(false),
       osCode(defaultOsCode)
     {
         unzFile_f = nullptr;
@@ -154,7 +132,7 @@ class QuaZipPrivate {
       bool goToFirstUnmappedFile();
       QHash<QString, unz64_file_pos> directoryCaseSensitive;
       QHash<QString, unz64_file_pos> directoryCaseInsensitive;
-      unz64_file_pos lastMappedDirectoryEntry;
+      unz64_file_pos lastMappedDirectoryEntry{};
       static QuazipTextCodec *defaultFileNameCodec;
       static uint defaultOsCode;
 };
@@ -176,7 +154,7 @@ void QuaZipPrivate::addCurrentFileToDirectoryMap(const QString &fileName)
         return;
     }
     // Adds current file to filename map as fileName
-    unz64_file_pos fileDirectoryPos;
+    unz64_file_pos fileDirectoryPos{};
     unzGetFilePos64(unzFile_f, &fileDirectoryPos);
     directoryCaseSensitive.insert(fileName, fileDirectoryPos);
     // Only add lowercase to directory map if not already there
@@ -407,15 +385,15 @@ QString QuaZip::getComment()const
   fakeThis->p->zipError=UNZ_OK;
   if(p->mode!=mdUnzip) {
     qWarning("QuaZip::getComment(): ZIP is not open in mdUnzip mode");
-    return QString();
+    return {};
   }
   unz_global_info64 globalInfo;
   QByteArray comment;
   if((fakeThis->p->zipError=unzGetGlobalInfo64(p->unzFile_f, &globalInfo))!=UNZ_OK)
-    return QString();
+    return {};
   comment.resize(globalInfo.size_comment);
   if((fakeThis->p->zipError=unzGetGlobalComment(p->unzFile_f, comment.data(), comment.size())) < 0)
-    return QString();
+    return {};
   fakeThis->p->zipError = UNZ_OK;
   unsigned flags = 0;
   return (unzGetFileFlags(p->unzFile_f, &flags) == UNZ_OK) && (flags & UNZ_ENCODING_UTF8)
@@ -570,14 +548,14 @@ QString QuaZip::getCurrentFileName()const
   fakeThis->p->zipError=UNZ_OK;
   if(p->mode!=mdUnzip) {
     qWarning("QuaZip::getCurrentFileName(): ZIP is not open in mdUnzip mode");
-    return QString();
+    return {};
   }
-  if(!isOpen()||!hasCurrentFile()) return QString();
+  if(!isOpen()||!hasCurrentFile()) return {};
   QByteArray fileName(MAX_FILE_NAME_LENGTH, 0);
   unz_file_info64 file_info;
   if((fakeThis->p->zipError=unzGetCurrentFileInfo64(p->unzFile_f, &file_info, fileName.data(), fileName.size(),
       nullptr, 0, nullptr, 0))!=UNZ_OK)
-    return QString();
+    return {};
   fileName.resize(file_info.size_filename);
   QString result = (file_info.flag & UNZ_ENCODING_UTF8)
     ? QString::fromUtf8(fileName) : p->fileNameCodec->toUnicode(fileName);
@@ -750,7 +728,7 @@ QStringList QuaZip::getFileNameList() const
 {
     QStringList list;
     if (!p->getFileInfoList(&list))
-        return QStringList();
+        return {};
     return list;
 }
 
@@ -758,7 +736,7 @@ QList<QuaZipFileInfo> QuaZip::getFileInfoList() const
 {
     QList<QuaZipFileInfo> list;
     if (!p->getFileInfoList(&list))
-        return QList<QuaZipFileInfo>();
+        return {};
     return list;
 }
 
@@ -766,7 +744,7 @@ QList<QuaZipFileInfo64> QuaZip::getFileInfoList64() const
 {
     QList<QuaZipFileInfo64> list;
     if (!p->getFileInfoList(&list))
-        return QList<QuaZipFileInfo64>();
+        return {};
     return list;
 }
 

--- a/quazip/quazipdir.cpp
+++ b/quazip/quazipdir.cpp
@@ -32,9 +32,9 @@ see quazip/(un)zip.h files for details. Basically it's the zlib license.
 class QuaZipDirPrivate: public QSharedData {
     friend class QuaZipDir;
 private:
-    QuaZipDirPrivate(QuaZip *_zip, const QString &_dir = QString()):
+    explicit QuaZipDirPrivate(QuaZip *_zip, const QString &_dir = QString()):
         zip(_zip), dir(_dir) {}
-    QuaZip *zip;
+    QuaZip *zip{};
     QString dir;
     QuaZip::CaseSensitivity caseSensitivity{QuaZip::csDefault};
     QDir::Filters filter{QDir::NoFilter};
@@ -93,7 +93,7 @@ bool QuaZipDir::cd(const QString &directoryName)
             if (!dir.cd(QLatin1String("/")))
                 return false;
         }
-        QStringList path = dirName.split(QLatin1String("/"), SkipEmptyParts);
+        const QStringList path = dirName.split(QLatin1String("/"), SkipEmptyParts);
         for (const auto& step : path) {
 #ifdef QUAZIP_QUAZIPDIR_DEBUG
             qDebug("QuaZipDir::cd(%s): going to %s",
@@ -199,14 +199,15 @@ static void QuaZipDir_convertInfoList(const QList<QuaZipFileInfo64> &from,
   */
 class QuaZipDirRestoreCurrent {
 public:
-    inline QuaZipDirRestoreCurrent(QuaZip *_zip):
+    explicit inline QuaZipDirRestoreCurrent(QuaZip *_zip):
         zip(_zip), currentFile(zip->getCurrentFileName()) {}
     inline ~QuaZipDirRestoreCurrent()
     {
         zip->setCurrentFile(currentFile);
     }
+    Q_DISABLE_COPY_MOVE(QuaZipDirRestoreCurrent)
 private:
-    QuaZip *zip;
+    QuaZip *zip{};
     QString currentFile;
 };
 /// \endcond
@@ -215,11 +216,11 @@ private:
 class QuaZipDirComparator
 {
     private:
-        QDir::SortFlags sort;
+        QDir::SortFlags sort{QDir::NoSort};
         static QString getExtension(const QString &name);
         int compareStrings(const QString &string1, const QString &string2);
     public:
-        inline QuaZipDirComparator(QDir::SortFlags _sort): sort(_sort) {}
+        explicit inline QuaZipDirComparator(QDir::SortFlags _sort): sort(_sort) {}
         bool operator()(const QuaZipFileInfo64 &info1, const QuaZipFileInfo64 &info2);
 };
 
@@ -376,7 +377,7 @@ QList<QuaZipFileInfo> QuaZipDir::entryInfoList(const QStringList &nameFilters,
 {
     QList<QuaZipFileInfo> result;
     if (!d->entryInfoList(nameFilters, filters, sort, result))
-        return QList<QuaZipFileInfo>();
+        return {};
     return result;
 }
 
@@ -391,7 +392,7 @@ QList<QuaZipFileInfo64> QuaZipDir::entryInfoList64(const QStringList &nameFilter
 {
     QList<QuaZipFileInfo64> result;
     if (!d->entryInfoList(nameFilters, filters, sort, result))
-        return QList<QuaZipFileInfo64>();
+        return {};
     return result;
 }
 
@@ -406,7 +407,7 @@ QStringList QuaZipDir::entryList(const QStringList &nameFilters,
 {
     QStringList result;
     if (!d->entryInfoList(nameFilters, filters, sort, result))
-        return QStringList();
+        return {};
     return result;
 }
 

--- a/quazip/quazipfile.cpp
+++ b/quazip/quazipfile.cpp
@@ -40,35 +40,35 @@ technique known as the Pimpl (private implementation) idiom.
 class QuaZipFilePrivate {
   friend class QuaZipFile;
   private:
-    Q_DISABLE_COPY(QuaZipFilePrivate)
+    Q_DISABLE_COPY_MOVE(QuaZipFilePrivate)
     /// The pointer to the associated QuaZipFile instance.
-    QuaZipFile *q;
+    QuaZipFile *q{};
     /// The QuaZip object to work with.
-    QuaZip *zip;
+    QuaZip *zip{};
     /// The file name.
     QString fileName;
     /// Case sensitivity mode.
-    QuaZip::CaseSensitivity caseSensitivity;
+    QuaZip::CaseSensitivity caseSensitivity{QuaZip::csDefault};
     /// Whether this file is opened in the raw mode.
-    bool raw;
+    bool raw{};
     /// Write position to keep track of.
     /**
       QIODevice::pos() is broken for non-seekable devices, so we need
       our own position.
       */
-    qint64 writePos;
+    qint64 writePos{};
     /// Uncompressed size to write along with a raw file.
-    quint64 uncompressedSize;
+    quint64 uncompressedSize{};
     /// CRC to write along with a raw file.
-    quint32 crc;
+    quint32 crc{};
     /// Whether \ref zip points to an internal QuaZip instance.
     /**
       This is true if the archive was opened by name, rather than by
       supplying an existing QuaZip instance.
       */
-    bool internal;
+    bool internal{true};
     /// The last error.
-    int zipError;
+    int zipError{UNZ_OK};
     /// Resets \ref zipError.
     inline void resetZipError() const {setZipError(UNZ_OK);}
     /// Sets the zip error.
@@ -80,38 +80,19 @@ class QuaZipFilePrivate {
     void setZipError(int zipError) const;
     /// The constructor for the corresponding QuaZipFile constructor.
     inline QuaZipFilePrivate(QuaZipFile *_q):
-      q(_q),
-      zip(nullptr),
-      caseSensitivity(QuaZip::csDefault),
-      raw(false),
-      writePos(0),
-      uncompressedSize(0),
-      crc(0),
-      internal(true),
-      zipError(UNZ_OK) {}
+      q(_q)
+    {
+    }
     /// The constructor for the corresponding QuaZipFile constructor.
     inline QuaZipFilePrivate(QuaZipFile *_q, const QString &zipName):
-      q(_q),
-      caseSensitivity(QuaZip::csDefault),
-      raw(false),
-      writePos(0),
-      uncompressedSize(0),
-      crc(0),
-      internal(true),
-      zipError(UNZ_OK)
+      q(_q)
       {
         zip=new QuaZip(zipName);
       }
     /// The constructor for the corresponding QuaZipFile constructor.
     inline QuaZipFilePrivate(QuaZipFile *_q, const QString &zipName, const QString &_fileName,
         QuaZip::CaseSensitivity cs):
-      q(_q),
-      raw(false),
-      writePos(0),
-      uncompressedSize(0),
-      crc(0),
-      internal(true),
-      zipError(UNZ_OK)
+      q(_q)
       {
         zip=new QuaZip(zipName);
         this->fileName=_fileName;
@@ -123,12 +104,9 @@ class QuaZipFilePrivate {
     inline QuaZipFilePrivate(QuaZipFile *_q, QuaZip *_zip):
       q(_q),
       zip(_zip),
-      raw(false),
-      writePos(0),
-      uncompressedSize(0),
-      crc(0),
-      internal(false),
-      zipError(UNZ_OK) {}
+      internal(false)
+      {
+      }
     /// The destructor.
     inline ~QuaZipFilePrivate()
     {
@@ -188,7 +166,7 @@ QString QuaZipFile::getActualFileName()const
 {
   p->setZipError(UNZ_OK);
   if (p->zip == nullptr || (openMode() & WriteOnly))
-    return QString();
+      return {};
   QString name=p->zip->getCurrentFileName();
   if(name.isNull())
     p->setZipError(p->zip->getZipError());
@@ -544,7 +522,7 @@ QByteArray QuaZipFile::getLocalExtraField()
     int err = unzGetLocalExtrafield(p->zip->getUnzFile(), extra.data(), static_cast<uint>(extra.size()));
     if (err < 0) {
         p->setZipError(err);
-        return QByteArray();
+        return {};
     }
     return extra;
 }

--- a/quazip/quazipfile.h
+++ b/quazip/quazipfile.h
@@ -75,7 +75,7 @@ class QUAZIP_EXPORT QuaZipFile: public QIODevice {
   friend class QuaZipFilePrivate;
   Q_OBJECT
   private:
-    QuaZipFilePrivate *p;
+    QuaZipFilePrivate *p{};
     // these are not supported nor implemented
     QuaZipFile(const QuaZipFile& that);
     QuaZipFile& operator=(const QuaZipFile& that);

--- a/quazip/quazipnewinfo.cpp
+++ b/quazip/quazipnewinfo.cpp
@@ -87,13 +87,12 @@ QuaZipNewInfo::QuaZipNewInfo(const QuaZipFileInfo64 &existing)
 }
 
 QuaZipNewInfo::QuaZipNewInfo(const QString& _name):
-  name(_name), dateTime(QDateTime::currentDateTime()), internalAttr(0), externalAttr(0),
-  uncompressedSize(0)
+  name(_name), dateTime(QDateTime::currentDateTime())
 {
 }
 
 QuaZipNewInfo::QuaZipNewInfo(const QString& _name, const QString& file):
-  name(_name), internalAttr(0), externalAttr(0), uncompressedSize(0)
+  name(_name)
 {
   QFileInfo info(file);
   QDateTime lm = info.lastModified();
@@ -106,7 +105,7 @@ QuaZipNewInfo::QuaZipNewInfo(const QString& _name, const QString& file):
 }
 
 QuaZipNewInfo::QuaZipNewInfo(const QString& _name, const QString& file, const QDateTime& _dateTime):
-  name(_name), dateTime(_dateTime), internalAttr(0), externalAttr(0), uncompressedSize(0)
+  name(_name), dateTime(_dateTime)
 {
   QFileInfo info(file);
   if (info.exists()) {

--- a/quazip/quazipnewinfo.h
+++ b/quazip/quazipnewinfo.h
@@ -61,14 +61,14 @@ struct QUAZIP_EXPORT QuaZipNewInfo {
    **/
   QDateTime dateTime;
   /// File internal attributes.
-  quint16 internalAttr;
+  quint16 internalAttr{};
   /// File external attributes.
   /**
     The highest 16 bits contain Unix file permissions and type (dir or
     file). The constructor QuaZipNewInfo(const QString&, const QString&)
     takes permissions from the provided file.
     */
-  quint32 externalAttr;
+  quint32 externalAttr{};
   /// File comment.
   /** Will be encoded in UTF-8 encoding.
    **/
@@ -81,7 +81,7 @@ struct QUAZIP_EXPORT QuaZipNewInfo {
   /** This is only needed if you are using raw file zipping mode, i. e.
    * adding precompressed file in the zip archive.
    **/
-  ulong uncompressedSize;
+  ulong uncompressedSize{};
   /// Constructs QuaZipNewInfo instance.
   /** Initializes name with \a name, dateTime with current date and
    * time. Attributes are initialized with zeros, comment and extra

--- a/quazip/unzip.c
+++ b/quazip/unzip.c
@@ -631,7 +631,7 @@ extern unzFile unzOpenInternal (voidpf file,
 
         if (ZSEEK64(us.z_filefunc, us.filestream,
                                       central_pos,ZLIB_FILEFUNC_SEEK_SET)!=0)
-        err=UNZ_ERRNO;
+            err=UNZ_ERRNO;
 
         /* the signature, already checked */
         if (unz64local_getLong(&us.z_filefunc, us.filestream,&uL)!=UNZ_OK)


### PR DESCRIPTION
Some simple fixes like:
- init all members (makes initialization list smaller)
- add some const for qt container detach in for loops
- avoid repeating return type
- mark single-argument constructor with explicit
- indentation
- missing documentation of argument (doxygen)